### PR TITLE
Negative power restrictions

### DIFF
--- a/src/org/mcteam/factions/Conf.java
+++ b/src/org/mcteam/factions/Conf.java
@@ -34,6 +34,9 @@ public class Conf {
 	public static int factionTagLengthMax = 10;
 	public static boolean factionTagForceUpperCase = false;
 	
+	// Disallow joining/leaving/kicking while power is negative
+	public static boolean negativerestrict = false;
+
 	// Configuration on the Faction tag in chat messages.
 	
 	public static boolean chatTagEnabled = true;

--- a/src/org/mcteam/factions/FPlayer.java
+++ b/src/org/mcteam/factions/FPlayer.java
@@ -371,6 +371,11 @@ public class FPlayer {
 			return;
 		}
 		
+		if (Conf.negativerestrict && this.getPower() < 0) {
+			sendMessage("You cannot leave until your power is positive.");
+			return;
+		}
+
 		myFaction.sendMessage(this.getNameAndRelevant(myFaction) + Conf.colorSystem + " left your faction.");
 		this.resetFactionData();
 		

--- a/src/org/mcteam/factions/commands/FCommandJoin.java
+++ b/src/org/mcteam/factions/commands/FCommandJoin.java
@@ -35,10 +35,14 @@ public class FCommandJoin extends FBaseCommand {
 			sendMessage("You must leave your current faction first.");
 			return;
 		}
-		
 		if( ! faction.getOpen() && ! faction.isInvited(me)) {
 			sendMessage("This guild requires invitation.");
 			faction.sendMessage(me.getNameAndRelevant(faction)+Conf.colorSystem+" tried to join your faction.");
+			return;
+		}
+
+		if (Conf.negativerestrict && me.getPower() < 0) {
+			sendMessage("You cannot join until your power is positive.");
 			return;
 		}
 

--- a/src/org/mcteam/factions/commands/FCommandKick.java
+++ b/src/org/mcteam/factions/commands/FCommandKick.java
@@ -40,6 +40,11 @@ public class FCommandKick extends FBaseCommand {
 			return;
 		}
 		
+		if (Conf.negativerestrict && you.getPower() < 0) {
+			sendMessage("You cannot kick that member until their power is positive.");
+			return;
+		}
+
 		myFaction.deinvite(you);
 		you.resetFactionData();
 		


### PR DESCRIPTION
Added a configuration variable that disallows faction joining and leaving while power is negative. Also restricts faction owner/moderator from kicking negative power members.
