### PR TITLE
Made Faction Homes Obey Worlds

### DIFF
--- a/src/org/mcteam/factions/listeners/FactionsPlayerListener.java
+++ b/src/org/mcteam/factions/listeners/FactionsPlayerListener.java
@@ -334,7 +334,7 @@ public class FactionsPlayerListener extends PlayerListener{
 	public void onPlayerRespawn(PlayerRespawnEvent event) {
 		FPlayer me = FPlayer.get(event.getPlayer());
 		Location home = me.getFaction().getHome();
-		if (Conf.homesEnabled && Conf.homesTeleportToOnDeath && home != null) {
+		if (Conf.homesEnabled && Conf.homesTeleportToOnDeath && home != null && !Conf.worldsNoPowerLoss.contains(event.getPlayer().getWorld().getName())) {
 			event.setRespawnLocation(home);
 		}
 	}


### PR DESCRIPTION
Edited the onPlayerRespawn to obey the 'worldsNoPowerLoss' config options. We were having issues in that someone was dying in a world we didn't have factions on and then getting taken to their faction home on the other world, instead of respawning at the spawn point of the world they died in.
