### PR TITLE
Disable pvp between neutral faction (conf)

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -71,6 +71,7 @@ public class Conf {
 	public static double homesTeleportAllowedEnemyDistance = 32;
 	public static boolean homesTeleportIgnoreEnemiesIfInOwnTerritory = true;
 	
+	public static boolean disablePVPBetweenNeutralFaction = false;
 	public static boolean disablePVPForFactionlessPlayers = false;
 	public static int noPVPDamageToOthersForXSecondsAfterLogin = 3;
 	

--- a/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -188,6 +188,12 @@ public class FactionsEntityListener extends EntityListener {
 		
 		Relation relation = defender.getRelation(attacker);
 		
+		// You can not hurt neutral factions
+		if (relation.isNeutral() && Conf.disablePVPBetweenNeutralFaction) {
+		attacker.sendMessage("You can't hurt neutral factions");
+		return false;
+		}
+		
 		// Players without faction may be hurt anywhere
 		if (defender.getFaction().isNone()) {
 			return true;


### PR DESCRIPTION
New setting in conf.json: "disablePVPBetweenNeutralFaction": false whether PvP damage will be disabled  between neutral faction

Change-Id: I08eee177fbe69d1466a267e67ec3fd0389f83499
