### PR TITLE
Allow Factions to defend their territory from Factionless PVP protected players

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -75,6 +75,8 @@ public class Conf {
 	
 	public static boolean disablePVPBetweenNeutralFactions = false;
 	public static boolean disablePVPForFactionlessPlayers = false;
+	public static boolean enablePVPAgainstFactionlessInAttackersLand = false;
+	
 	public static int noPVPDamageToOthersForXSecondsAfterLogin = 3;
 
 	public static boolean peacefulTerritoryDisablePVP = true;

--- a/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -206,6 +206,10 @@ public class FactionsEntityListener extends EntityListener {
 			attacker.sendMessage("You can't hurt other players until you join a faction.");
 			return false;
 		}
+		else if (defLocFaction == attacker.getFaction() && Conf.enablePVPAgainstFactionlessInAttackersLand) {
+			// Allow PVP vs. Factionless in attacker's faction territory
+			return true;
+		}
 		else if (!defender.hasFaction() && Conf.disablePVPForFactionlessPlayers) {
 			attacker.sendMessage("You can't hurt players who are not currently in a faction.");
 			return false;


### PR DESCRIPTION
Some players were dropping out of their factions to scout enemy bases and use the factionless protection to their advantage in combat.
