### PR TITLE
Allow moderators to control themselves

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -22,6 +22,12 @@ public class Conf {
 	public static ChatColor colorCommand = ChatColor.AQUA;
 	public static ChatColor colorParameter = ChatColor.DARK_AQUA;
 	
+	//Money
+	public static boolean bankEnabled = true;
+	public static boolean bankMembersCanWithdraw = false; //Have to be at least moderator to withdraw or pay money to another faction
+	public static boolean bankFactionPaysCosts = true; //The faction pays for faction command costs, such as sethome
+	public static boolean bankFactionPaysLandCosts = true; //The faction pays for land claiming costs.
+	
 	// Power
 	public static double powerPlayerMax = 10.0;
 	public static double powerPlayerMin = -10.0;

--- a/src/com/massivecraft/factions/FPlayer.java
+++ b/src/com/massivecraft/factions/FPlayer.java
@@ -623,11 +623,23 @@ public class FPlayer {
 		if (Econ.enabled() && !Conf.adminBypassPlayers.contains(this.playerName)) {
 			double cost = Econ.calculateClaimCost(ownedLand, otherFaction.isNormal());
 			String costString = Econ.moneyString(cost);
-			if (!Econ.deductMoney(this.playerName, cost)) {
-				sendMessage("Claiming this land will cost "+costString+", which you can't currently afford.");
-				return false;
+			
+			if(Conf.bankFactionPaysLandCosts && this.hasFaction()) {
+				Faction faction = this.getFaction();
+				
+				if(!faction.removeMoney(cost)) {
+					sendMessage("It costs "+costString+" to claim this land, which your faction can't currently afford.");
+					return false;
+				} else {
+					sendMessage(faction.getTag()+" has paid "+costString+" to claim some land.");
+				}
+			} else {
+				if (!Econ.deductMoney(this.playerName, cost)) {
+					sendMessage("Claiming this land will cost "+costString+", which you can't currently afford.");
+					return false;
+				}
+				sendMessage("You have paid "+costString+" to claim this land.");
 			}
-			sendMessage("You have paid "+costString+" to claim this land.");
 		}
 
 		// announce success

--- a/src/com/massivecraft/factions/Faction.java
+++ b/src/com/massivecraft/factions/Faction.java
@@ -39,6 +39,7 @@ public class Faction {
 	private String description;
 	private Location home;
 	private transient long lastPlayerLoggedOffTime;
+	private double money;
 	
 	// -------------------------------------------- //
 	// Construct
@@ -54,6 +55,7 @@ public class Faction {
 		this.peaceful = false;
 		this.peacefulExplosionsEnabled = false;
 		this.permanent = false;
+		this.money = 0.0;
 	}
 	
 	// -------------------------------------------- //
@@ -592,6 +594,30 @@ public class Faction {
 		return false;
 	}
 
+	public double getMoney() {
+		return this.money;
+	}
+	
+	public boolean addMoney(double amount)	{
+		if ( amount > 0.0 )
+		{
+			this.money += amount;
+			return true;
+		}
+		return false;
+	}
+	
+	public boolean removeMoney( double amount )	{
+		if (amount <= 0.0 )
+			return false;
+		
+		if (amount > this.money )
+			return false;
+		
+		this.money -= amount;
+		return true;
+	}
+	
 	
 	//----------------------------------------------//
 	// Persistance and entity management

--- a/src/com/massivecraft/factions/Factions.java
+++ b/src/com/massivecraft/factions/Factions.java
@@ -97,12 +97,14 @@ public class Factions extends JavaPlugin {
 		commands.add(new FCommandAutoClaim());
 		commands.add(new FCommandAutoSafeclaim());
 		commands.add(new FCommandAutoWarclaim());
+		commands.add(new FCommandBalance());
 		commands.add(new FCommandBypass());
 		commands.add(new FCommandChat());
 		commands.add(new FCommandClaim());
 		commands.add(new FCommandConfig());
 		commands.add(new FCommandCreate());
 		commands.add(new FCommandDeinvite());
+		commands.add(new FCommandDeposit());
 		commands.add(new FCommandDescription());
 		commands.add(new FCommandDisband());
 		commands.add(new FCommandHome());
@@ -118,6 +120,7 @@ public class Factions extends JavaPlugin {
 		commands.add(new FCommandOpen());
 		commands.add(new FCommandOwner());
 		commands.add(new FCommandOwnerList());
+		commands.add(new FCommandPay());
 		commands.add(new FCommandPower());
 		commands.add(new FCommandPeaceful());
 		commands.add(new FCommandPermanent());
@@ -137,6 +140,7 @@ public class Factions extends JavaPlugin {
 		commands.add(new FCommandVersion());
 		commands.add(new FCommandWarclaim());
 		commands.add(new FCommandWarunclaimall());
+		commands.add(new FCommandWithdraw());
 		
 		// Ensure base folder exists!
 		this.getDataFolder().mkdirs();

--- a/src/com/massivecraft/factions/commands/FBaseCommand.java
+++ b/src/com/massivecraft/factions/commands/FBaseCommand.java
@@ -247,19 +247,40 @@ public class FBaseCommand {
 
 		String desc = this.helpDescription.toLowerCase();
 
+		Faction faction = me.getFaction();
+		
 		// pay up
 		if (cost > 0.0) {
 			String costString = Econ.moneyString(cost);
-			if (!Econ.deductMoney(me.getName(), cost)) {
-				sendMessage("It costs "+costString+" to "+desc+", which you can't currently afford.");
-				return false;
+			if(Conf.bankFactionPaysCosts) {
+				if(!faction.removeMoney(cost)) {
+					sendMessage("It costs "+costString+" to "+desc+", which your faction can't currently afford.");
+					return false;
+				} else {
+					sendMessage(faction.getTag()+" has paid "+costString+" to "+desc+".");
+				}
+					
+			} else {
+				if (!Econ.deductMoney(me.getName(), cost)) {
+					sendMessage("It costs "+costString+" to "+desc+", which you can't currently afford.");
+					return false;
+				}
+				sendMessage("You have paid "+costString+" to "+desc+".");
 			}
-			sendMessage("You have paid "+costString+" to "+desc+".");
 		}
 		// wait... we pay you to use this command?
 		else {
+			
 			String costString = Econ.moneyString(-cost);
-			Econ.addMoney(me.getName(), -cost);
+			
+			if(Conf.bankFactionPaysCosts) {
+				faction.addMoney(-cost);
+				sendMessage(faction.getTag()+" has been paid "+costString+" to "+desc+".");
+			} else {
+				Econ.addMoney(me.getName(), -cost);
+			}
+			
+			
 			sendMessage("You have been paid "+costString+" to "+desc+".");
 		}
 		return true;

--- a/src/com/massivecraft/factions/commands/FCommandBalance.java
+++ b/src/com/massivecraft/factions/commands/FCommandBalance.java
@@ -1,0 +1,31 @@
+package com.massivecraft.factions.commands;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.Econ;
+import com.massivecraft.factions.Faction;
+
+public class FCommandBalance extends FBaseCommand {
+	
+	public FCommandBalance() {
+		aliases.add("balance");
+		aliases.add("money");
+		
+		helpDescription = "Shows the faction's current balance";
+	}
+	
+	@Override
+	public void perform() {
+		if ( ! assertHasFaction()) {
+			return;
+		}
+		
+		if (!Conf.bankEnabled) {
+			return;
+		}
+		
+		Faction faction = me.getFaction();
+		
+		sendMessage(Conf.colorChrome+"Balance: "+ Econ.moneyString(faction.getMoney()));
+	}
+	
+}

--- a/src/com/massivecraft/factions/commands/FCommandDeposit.java
+++ b/src/com/massivecraft/factions/commands/FCommandDeposit.java
@@ -1,0 +1,60 @@
+package com.massivecraft.factions.commands;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.Econ;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.Faction;
+
+public class FCommandDeposit extends FBaseCommand {
+	
+	public FCommandDeposit() {
+		aliases.add("deposit");
+		
+		helpDescription = "Deposit money into your faction's bank";
+		requiredParameters.add("amount");
+	}
+	
+	@Override
+	public void perform() {
+		if ( ! assertHasFaction()) {
+			return;
+		}
+		
+		if (!Conf.bankEnabled) {
+			return;
+		}
+		
+		double amount = 0.0;
+		
+		Faction faction = me.getFaction();
+		
+		if (parameters.size() == 1) {
+			try {
+				amount = Double.parseDouble(parameters.get(0));
+			} catch (NumberFormatException e) {
+				// wasn't valid
+			}
+		}
+		
+		String amountString = Econ.moneyString(amount);
+		
+		if( amount > 0.0 ) {
+			if( !Econ.deductMoney(me.getName(), amount ) ) {
+				sendMessage("You cannot afford to deposit that much.");
+			}
+			else
+			{
+				faction.addMoney(amount);
+				sendMessage("You have deposited "+amountString+" into "+faction.getTag()+"'s bank.");
+				sendMessage(faction.getTag()+" now has "+Econ.moneyString(faction.getMoney()));
+				
+				for (FPlayer fplayer : FPlayer.getAllOnline()) {
+					if (fplayer.getFaction() == faction) {
+						fplayer.sendMessage(me.getNameAndRelevant(fplayer)+Conf.colorSystem+" has deposited "+amountString);
+					}
+				}
+			}
+		}
+	}
+	
+}

--- a/src/com/massivecraft/factions/commands/FCommandDisband.java
+++ b/src/com/massivecraft/factions/commands/FCommandDisband.java
@@ -1,6 +1,7 @@
 package com.massivecraft.factions.commands;
 
 import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.Econ;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.FPlayer;
@@ -67,6 +68,11 @@ public class FCommandDisband extends FBaseCommand {
 				fplayer.sendMessage(me.getNameAndRelevant(fplayer)+Conf.colorSystem+" disbanded the faction "+faction.getTag(fplayer)+".");
 			}
 		}
+		
+		if (Conf.bankEnabled) {
+			Econ.addMoney(me.getName(), me.getFaction().getMoney() ); //Give all the faction's money to the disbander
+		}		
+		
 		Faction.delete( faction.getId() );
 		SpoutFeatures.updateAppearances();
 

--- a/src/com/massivecraft/factions/commands/FCommandHelp.java
+++ b/src/com/massivecraft/factions/commands/FCommandHelp.java
@@ -79,6 +79,13 @@ public class FCommandHelp extends FBaseCommand {
 		helpPages.add(pageLines);
 		
 		pageLines = new ArrayList<String>();
+		pageLines.add( new FCommandBalance().getUseageTemplate() );
+		pageLines.add( new FCommandDeposit().getUseageTemplate() );
+		pageLines.add( new FCommandWithdraw().getUseageTemplate() );
+		pageLines.add( new FCommandPay().getUseageTemplate() );
+		helpPages.add(pageLines);
+		
+		pageLines = new ArrayList<String>();
 		pageLines.add( new FCommandClaim().getUseageTemplate() );
 		pageLines.add( new FCommandAutoClaim().getUseageTemplate() );
 		pageLines.add( new FCommandUnclaim().getUseageTemplate() );

--- a/src/com/massivecraft/factions/commands/FCommandPay.java
+++ b/src/com/massivecraft/factions/commands/FCommandPay.java
@@ -1,0 +1,73 @@
+package com.massivecraft.factions.commands;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.Econ;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.struct.Role;
+
+public class FCommandPay extends FBaseCommand {
+	
+	public FCommandPay() {
+		aliases.add("pay");
+		
+		helpDescription = "Pay another faction money from your faction's bank";
+		requiredParameters.add("faction");
+		requiredParameters.add("amount");
+	}
+	
+	@Override
+	public void perform() {
+		if ( ! assertHasFaction()) {
+			return;
+		}
+		
+		if (!Conf.bankEnabled) {
+			return;
+		}
+		
+		if ( !Conf.bankMembersCanWithdraw && !assertMinRole(Role.MODERATOR)) {
+			sendMessage("Only faction moderators or admins are able to pay another faction.");
+			return;
+		}
+		
+		double amount = 0.0;
+		
+		Faction us = me.getFaction();
+		Faction them = null;
+		
+		if (parameters.size() == 2) {
+			try {
+				them = Faction.findByTag(parameters.get(0));
+				amount = Double.parseDouble(parameters.get(1));
+			} catch (NumberFormatException e) {
+				// wasn't valid
+			}
+		}
+		
+		if(them == null) {
+			sendMessage(parameters.get(0)+" could not be found.");
+			return;
+		}
+		
+		String amountString = Econ.moneyString(amount);
+		
+		if( amount > 0.0 ) {
+			if( amount > us.getMoney() ) {
+				amount = us.getMoney();
+			}
+			
+			us.removeMoney(amount);
+			them.addMoney(amount);
+			sendMessage("You have paid "+amountString+" from "+us.getTag()+"'s bank to "+them.getTag()+"'s bank.");
+			sendMessage(us.getTag()+" now has "+Econ.moneyString(us.getMoney()));
+			
+			for (FPlayer fplayer : FPlayer.getAllOnline()) {
+				if (fplayer.getFaction() == us || fplayer.getFaction() == them) {
+					fplayer.sendMessage(me.getNameAndRelevant(fplayer)+Conf.colorSystem+" has sent "+amountString+" from "+us.getTag()+" to "+them.getTag() );
+				}
+			}
+		}
+	}
+	
+}

--- a/src/com/massivecraft/factions/commands/FCommandUnclaim.java
+++ b/src/com/massivecraft/factions/commands/FCommandUnclaim.java
@@ -76,16 +76,31 @@ public class FCommandUnclaim extends FBaseCommand {
 			double refund = Econ.calculateClaimRefund(myFaction.getLandRounded());
 			// a real refund
 			if (refund > 0.0) {
-				Econ.addMoney(player.getName(), refund);
-				moneyBack = " They received a refund of "+Econ.moneyString(refund)+".";
+				if(Conf.bankFactionPaysLandCosts) {
+					Faction faction = me.getFaction();
+					faction.addMoney(refund);
+					moneyBack = " "+faction.getTag()+" received a refund of "+Econ.moneyString(refund)+".";
+				} else {
+					Econ.addMoney(player.getName(), refund);
+					moneyBack = " They received a refund of "+Econ.moneyString(refund)+".";
+				}
 			}
 			// wait, you're charging people to unclaim land? outrageous
 			else if (refund < 0.0) {
-				if (!Econ.deductMoney(player.getName(), -refund)) {
-					sendMessage("Unclaiming this land will cost "+Econ.moneyString(-refund)+", which you can't currently afford.");
-					return;
+				if(Conf.bankFactionPaysLandCosts) {
+					Faction faction = me.getFaction();
+					if(!faction.removeMoney(-refund)) {
+						sendMessage("Unclaiming this land will cost "+Econ.moneyString(-refund)+", which your faction can't currently afford.");
+						return;
+					}
+					moneyBack = " It cost "+faction.getTag()+" "+Econ.moneyString(refund)+".";
+				} else {
+					if (!Econ.deductMoney(player.getName(), -refund)) {
+						sendMessage("Unclaiming this land will cost "+Econ.moneyString(-refund)+", which you can't currently afford.");
+						return;
+					}
+					moneyBack = " It cost them "+Econ.moneyString(refund)+".";
 				}
-				moneyBack = " It cost them "+Econ.moneyString(refund)+".";
 			}
 			// no refund
 			else {

--- a/src/com/massivecraft/factions/commands/FCommandUnclaimall.java
+++ b/src/com/massivecraft/factions/commands/FCommandUnclaimall.java
@@ -37,14 +37,30 @@ public class FCommandUnclaimall extends FBaseCommand {
 			double refund = Econ.calculateTotalLandRefund(myFaction.getLandRounded());
 			// a real refund
 			if (refund > 0.0) {
-				Econ.addMoney(player.getName(), refund);
-				moneyBack = " They received a refund of "+Econ.moneyString(refund)+".";
+				if(Conf.bankFactionPaysLandCosts) {
+					Faction faction = me.getFaction();
+					faction.addMoney(refund);
+					moneyBack = " "+faction.getTag()+" received a refund of "+Econ.moneyString(refund)+".";
+				} else {
+					Econ.addMoney(player.getName(), refund);
+					moneyBack = " They received a refund of "+Econ.moneyString(refund)+".";
+				}
 			}
 			// wait, you're charging people to unclaim land? outrageous
 			else if (refund < 0.0) {
-				if (!Econ.deductMoney(player.getName(), -refund)) {
-					sendMessage("Unclaiming all faction land will cost "+Econ.moneyString(-refund)+", which you can't currently afford.");
-					return;
+				if(Conf.bankFactionPaysLandCosts) {
+					Faction faction = me.getFaction();
+					if(!faction.removeMoney(-refund)) {
+						sendMessage("Unclaiming all faction land will cost "+Econ.moneyString(-refund)+", which your faction can't currently afford.");
+						return;
+					}
+					moneyBack = " It cost "+faction.getTag()+" "+Econ.moneyString(refund)+".";
+				} else {
+					if (!Econ.deductMoney(player.getName(), -refund)) {
+						sendMessage("Unclaiming all faction land will cost "+Econ.moneyString(-refund)+", which you can't currently afford.");
+						return;
+					}
+					moneyBack = " It cost them "+Econ.moneyString(refund)+".";
 				}
 				moneyBack = " It cost them "+Econ.moneyString(refund)+".";
 			}
@@ -55,7 +71,7 @@ public class FCommandUnclaimall extends FBaseCommand {
 		}
 
 		Board.unclaimAll(myFaction.getId());
-		myFaction.sendMessage(me.getNameAndRelevant(myFaction)+Conf.colorSystem+" unclaimed ALL of your factions land."+moneyBack);
+		myFaction.sendMessage(me.getNameAndRelevant(myFaction)+Conf.colorSystem+" unclaimed ALL of your faction's land."+moneyBack);
 	}
 	
 }

--- a/src/com/massivecraft/factions/commands/FCommandWithdraw.java
+++ b/src/com/massivecraft/factions/commands/FCommandWithdraw.java
@@ -1,0 +1,65 @@
+package com.massivecraft.factions.commands;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.Econ;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.struct.Role;
+
+public class FCommandWithdraw extends FBaseCommand {
+	
+	public FCommandWithdraw() {
+		aliases.add("withdraw");
+		
+		helpDescription = "Withdraw money from your faction's bank";
+		requiredParameters.add("amount");
+	}
+	
+	@Override
+	public void perform() {
+		if ( ! assertHasFaction()) {
+			return;
+		}
+		
+		if (!Conf.bankEnabled) {
+			return;
+		}
+		
+		if ( !Conf.bankMembersCanWithdraw && !assertMinRole(Role.MODERATOR)) {
+			sendMessage("Only faction moderators or admins are able to withdraw from the bank.");
+			return;
+		}
+		
+		double amount = 0.0;
+		
+		Faction faction = me.getFaction();
+		
+		if (parameters.size() == 1) {
+			try {
+				amount = Double.parseDouble(parameters.get(0));
+			} catch (NumberFormatException e) {
+				// wasn't valid
+			}
+		}
+		
+		String amountString = Econ.moneyString(amount);
+		
+		if( amount > 0.0 ) {
+			if( amount > faction.getMoney() ) {
+				amount = faction.getMoney();
+			}
+			
+			faction.removeMoney(amount);
+			Econ.addMoney(me.getName(), amount);
+			sendMessage("You have withdrawn "+amountString+" from "+faction.getTag()+"'s bank.");
+			sendMessage(faction.getTag()+" now has "+Econ.moneyString(faction.getMoney()));
+			
+			for (FPlayer fplayer : FPlayer.getAllOnline()) {
+				if (fplayer.getFaction() == faction) {
+					fplayer.sendMessage(me.getNameAndRelevant(fplayer)+Conf.colorSystem+" has withdrawn "+amountString);
+				}
+			}
+		}
+	}
+	
+}


### PR DESCRIPTION
This is to enable moderators to set their own title in a faction. If you would rather this behaviour happened inside the faction title command itself I will amend the patch. 
