### PR TITLE
Added f info command for a quick lookup of players and factions.

### DIFF
--- a/src/com/massivecraft/factions/Factions.java
+++ b/src/com/massivecraft/factions/Factions.java
@@ -109,6 +109,7 @@ public class Factions extends JavaPlugin {
 		commands.add(new FCommandDescription());
 		commands.add(new FCommandDisband());
 		commands.add(new FCommandHome());
+		commands.add(new FCommandInfo());
 		commands.add(new FCommandInvite());
 		commands.add(new FCommandJoin());
 		commands.add(new FCommandKick());

--- a/src/com/massivecraft/factions/commands/FCommandHelp.java
+++ b/src/com/massivecraft/factions/commands/FCommandHelp.java
@@ -59,12 +59,12 @@ public class FCommandHelp extends FBaseCommand {
 		pageLines.add( new FCommandHelp().getUseageTemplate() );
 		pageLines.add( new FCommandList().getUseageTemplate() );
 		pageLines.add( new FCommandShow().getUseageTemplate() );
+		pageLines.add( new FCommandInfo().getUseageTemplate() );
 		pageLines.add( new FCommandPower().getUseageTemplate() );
 		pageLines.add( new FCommandJoin().getUseageTemplate() );
 		pageLines.add( new FCommandLeave().getUseageTemplate() );
 		pageLines.add( new FCommandChat().getUseageTemplate() );
 		pageLines.add( new FCommandHome().getUseageTemplate() );
-		pageLines.add( "Learn how to create a faction on the next page." );
 		helpPages.add(pageLines);
 		
 		pageLines = new ArrayList<String>();

--- a/src/com/massivecraft/factions/commands/FCommandInfo.java
+++ b/src/com/massivecraft/factions/commands/FCommandInfo.java
@@ -1,0 +1,48 @@
+package com.massivecraft.factions.commands;
+
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.FPlayer;
+import com.massivecraft.factions.Faction;
+
+public class FCommandInfo extends FBaseCommand {
+	
+	public FCommandInfo() {
+		aliases.add("info");
+		aliases.add("i");
+		
+		requiredParameters.add("player name|faction tag");
+		
+		helpDescription = "Lookup players or factions.";
+	}
+	
+	@Override
+	public void perform() {
+		
+		if( isLocked() ) {
+			sendLockMessage();
+			return;
+		}
+		
+		String filter = parameters.get(0).toLowerCase();
+		
+		for( FPlayer player : FPlayer.getAll() ) {
+			if( player.getName().toLowerCase().contains(filter)) {
+				String status = player.isOnline() ? "online" : "offline";
+				sendMessage(player.getNameAndRelevant(me)+Conf.colorSystem+" is "+status);
+			}
+		}
+		
+		for( Faction faction : Faction.getAll() ) {
+			if( faction.getTag().toLowerCase().contains(filter)) {
+				String tag = faction.getTag(me);
+				int online = faction.getOnlinePlayers().size();
+				int maxonline = faction.getFPlayers().size();
+				int power = faction.getPowerRounded();
+				int maxpower = faction.getPowerMaxRounded();
+				int land = faction.getLandRounded();
+				
+				sendMessage(tag+Conf.colorSystem+" have "+online+"/"+maxonline+" members online, "+land+" land and "+power+"/"+maxpower+" power.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
The /f who command is too slow and unwieldy for looking up the neutrality of a player running towards you or a faction's power mid-siege. This command allows players to quickly look up useful information by doing partial matches of faction tags and player names.
