### PR TITLE
Added new conf.json setting : bankCanBeUsedEverywhere (default: true) 

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -232,6 +232,7 @@ public class Conf
 	public static boolean bankMembersCanWithdraw = false; //Have to be at least moderator to withdraw or pay money to another faction
 	public static boolean bankFactionPaysCosts = true; //The faction pays for faction command costs, such as sethome
 	public static boolean bankFactionPaysLandCosts = true; //The faction pays for land claiming costs.
+	public static boolean bankCanBeUsedEverywhere = true; // If false, you must be on one of your claimed chunks to execute /f money deposit or /f money withdraw
 	
 	public static Set<String> worldsNoClaiming = new HashSet<String>();
 	public static Set<String> worldsNoPowerLoss = new HashSet<String>();

--- a/src/com/massivecraft/factions/cmd/CmdMoneyDeposit.java
+++ b/src/com/massivecraft/factions/cmd/CmdMoneyDeposit.java
@@ -1,5 +1,8 @@
 package com.massivecraft.factions.cmd;
 
+import com.massivecraft.factions.Board;
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.FLocation;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.integration.Econ;
 import com.massivecraft.factions.struct.Permission;
@@ -32,6 +35,16 @@ public class CmdMoneyDeposit extends FCommand
 		double amount = this.argAsDouble(0, 0d);
 		Faction faction = this.argAsFaction(1, myFaction);
 		if (faction == null) return;
+		if (!Conf.bankCanBeUsedEverywhere) {
+			FLocation floc = new FLocation(fme.getPlayer().getLocation());
+			Faction otherfaction = Board.getFactionAt(floc);
+			if (faction.getLandRounded() > 0) { // If you have more than 1 territory (= if you have a faction && if you have more than 1 claimed chunk)
+				if (faction != otherfaction) { // If you're not in your territory
+					msg("<b>You can't deposit unless you are on your faction's territory.");
+					return;
+				}
+			}
+		}
 		Econ.transferMoney(fme, fme, faction, amount);
 	}
 	

--- a/src/com/massivecraft/factions/cmd/CmdMoneyWithdraw.java
+++ b/src/com/massivecraft/factions/cmd/CmdMoneyWithdraw.java
@@ -1,5 +1,8 @@
 package com.massivecraft.factions.cmd;
 
+import com.massivecraft.factions.Board;
+import com.massivecraft.factions.Conf;
+import com.massivecraft.factions.FLocation;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.integration.Econ;
 import com.massivecraft.factions.struct.Permission;
@@ -29,6 +32,16 @@ public class CmdMoneyWithdraw extends FCommand
 		double amount = this.argAsDouble(0, 0d);
 		Faction faction = this.argAsFaction(1, myFaction);
 		if (faction == null) return;
+		if (!Conf.bankCanBeUsedEverywhere) {
+			FLocation floc = new FLocation(fme.getPlayer().getLocation());
+			Faction otherfaction = Board.getFactionAt(floc);
+			if (faction.getLandRounded() > 0) { // If you have more than 1 territory (= if you have a faction && if you have more than 1 claimed chunk)
+				if (faction != otherfaction) { // If you're not in your territory
+					msg("<b>You can't withdraw unless you are on your faction's territory.");
+					return;
+				}
+			}
+		}
 		Econ.transferMoney(fme, faction, fme, amount);
 	}
 }


### PR DESCRIPTION
If true : /f money deposit & /f money withdraw can be used everywhere
If false : both commands can only be used in one of your claimed chunks
(or everywhere if you've got no claimed chunks)
