### PR TITLE
Fixes all users showing up as 'you' in faction chat.

### DIFF
--- a/src/com/massivecraft/factions/listeners/FactionsChatEarlyListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsChatEarlyListener.java
@@ -45,8 +45,7 @@ public class FactionsChatEarlyListener extends PlayerListener
 		// Is it a faction chat message?
 		if (me.getChatMode() == ChatMode.FACTION)
 		{
-			
-			String message = String.format(Conf.factionChatFormat, me.describeTo(me), msg);
+			String message = String.format(Conf.factionChatFormat, ChatColor.stripColor(me.getNameAndTag()), msg);
 			me.getFaction().sendMessage(message);
 			
 			P.p.log(Level.INFO, ChatColor.stripColor("FactionChat "+me.getFaction().getTag()+": "+message));


### PR DESCRIPTION
Currently, all users show up as 'you' in faction chat due to what I presume was an oversight in a mass edit. This breaks faction chat pretty horribly as you can't figure out who's saying what, unless everyone wants to type their name in every message they send in faction chat.
