### PR TITLE
Added the possibility to set different amounts of power loss for PvP & PvE deaths 

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -33,7 +33,8 @@ public class Conf
 	public static double powerPlayerMax = 10.0;
 	public static double powerPlayerMin = -10.0;
 	public static double powerPerMinute = 0.2; // Default health rate... it takes 5 min to heal one power
-	public static double powerPerDeath = 4.0; // A death makes you lose 4 power
+	public static double powerPerPvPDeath = 4.0; // A PvP death makes you lose 4 power
+	public static double powerPerPvEDeath = 4.0; // A normal death makes you lose 4 power
 	public static boolean powerRegenOffline = false;  // does player power regenerate even while they're offline?
 	public static double powerOfflineLossPerDay = 0.0;  // players will lose this much power per day offline
 	public static double powerOfflineLossLimit = 0.0;  // players will no longer lose power from being offline once their power drops to this amount or less

--- a/src/com/massivecraft/factions/FPlayer.java
+++ b/src/com/massivecraft/factions/FPlayer.java
@@ -399,10 +399,15 @@ public class FPlayer extends PlayerEntity implements EconomyParticipator
 		}
 	}
 	
-	public void onDeath()
+	public void onDeath(String typeOfDeath)
 	{
 		this.updatePower();
-		this.alterPower(-Conf.powerPerDeath);
+		if (typeOfDeath.equals("PVP")) {
+			this.alterPower(-Conf.powerPerPvPDeath);
+		}
+		else {
+			this.alterPower(-Conf.powerPerPvEDeath);
+		}
 	}
 	
 	//----------------------------------------------//

--- a/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -39,7 +39,7 @@ public class FactionsEntityListener extends EntityListener
 	{
 		this.p = p;
 	}
-	
+
 	@Override
 	public void onEntityDeath(EntityDeathEvent event)
 	{
@@ -49,35 +49,46 @@ public class FactionsEntityListener extends EntityListener
 		Player player = (Player) entity;
 		FPlayer fplayer = FPlayers.i.get(player);
 		Faction faction = Board.getFactionAt(new FLocation(player.getLocation()));
-		
+
 		if ( ! faction.getFlag(FFlag.POWERLOSS))
 		{
 			fplayer.msg("<i>You didn't lose any power since the territory you died in works that way.");
 			return;
 		}
-		
+
 		if (Conf.worldsNoPowerLoss.contains(player.getWorld().getName()))
 		{
 			fplayer.msg("<i>You didn't lose any power due to the world you died in.");
 			return;
 		}
-		
-		fplayer.onDeath();
+
+		EntityDamageEvent lastDamageCause = player.getLastDamageCause();
+
+		if (lastDamageCause instanceof EntityDamageByEntityEvent) {
+			EntityDamageByEntityEvent entityEvent = (EntityDamageByEntityEvent)lastDamageCause;
+
+			if (entityEvent.getDamager() instanceof Player)	{ // if attacker is a player
+				fplayer.onDeath("PVP");
+				fplayer.msg("<i>Your power is now <h>"+fplayer.getPowerRounded()+" / "+fplayer.getPowerMaxRounded());
+				return;
+			}
+		}
+		fplayer.onDeath("other"); // Attacker is null (suicide), or is a mob
 		fplayer.msg("<i>Your power is now <h>"+fplayer.getPowerRounded()+" / "+fplayer.getPowerMaxRounded());
 	}
-	
+
 	@Override
 	public void onEntityDamage(EntityDamageEvent event)
 	{
 		if ( event.isCancelled()) return;
-		
+
 		if (event instanceof EntityDamageByEntityEvent)
 		{
 			EntityDamageByEntityEvent sub = (EntityDamageByEntityEvent)event;
 			if ( ! this.canDamagerHurtDamagee(sub))
 			{
-    			event.setCancelled(true);
-    		}
+				event.setCancelled(true);
+			}
 		}
 		// TODO: Add a no damage at all flag??
 		/*else if (Conf.safeZonePreventAllDamageToPlayers && isPlayerInSafeZone(event.getEntity()))
@@ -86,12 +97,12 @@ public class FactionsEntityListener extends EntityListener
 			event.setCancelled(true);
 		}*/
 	}
-	
+
 	@Override
 	public void onEntityExplode(EntityExplodeEvent event)
 	{
 		if ( event.isCancelled()) return;
-		
+
 		for (Block block : event.blockList())
 		{
 			Faction faction = Board.getFactionAt(new FLocation(block));
@@ -103,29 +114,29 @@ public class FactionsEntityListener extends EntityListener
 			}
 		}
 	}
-	
+
 	public boolean canDamagerHurtDamagee(EntityDamageByEntityEvent sub)
 	{
 		Entity damager = sub.getDamager();
 		Entity damagee = sub.getEntity();
 		int damage = sub.getDamage();
-		
+
 		if ( ! (damagee instanceof Player)) return true;
-		
+
 		FPlayer defender = FPlayers.i.get((Player)damagee);
-		
+
 		if (defender == null || defender.getPlayer() == null)
 		{
 			return true;
 		}
-		
+
 		Location defenderLoc = defender.getPlayer().getLocation();
-		
+
 		if (Conf.worldsIgnorePvP.contains(defenderLoc.getWorld().getName()))
 		{
 			return true;
 		}
-		
+
 		Faction defLocFaction = Board.getFactionAt(new FLocation(defenderLoc));
 
 		// for damage caused by projectiles, getDamager() returns the projectile... what we need to know is the source
@@ -135,7 +146,7 @@ public class FactionsEntityListener extends EntityListener
 		}
 
 		// Players can not take attack damage in a SafeZone, or possibly peaceful territory
-		
+
 		if (defLocFaction.getFlag(FFlag.PVP) == false)
 		{
 			if (damager instanceof Player)
@@ -146,37 +157,37 @@ public class FactionsEntityListener extends EntityListener
 			}
 			return defLocFaction.getFlag(FFlag.MONSTERS);
 		}
-		
+
 		if ( ! (damager instanceof Player))
 		{
 			return true;
 		}
-		
+
 		FPlayer attacker = FPlayers.i.get((Player)damager);
-		
+
 		if (attacker == null || attacker.getPlayer() == null)
 		{
 			return true;
 		}
-		
+
 		if (attacker.hasLoginPvpDisabled())
 		{
 			attacker.msg("<i>You can't hurt other players for " + Conf.noPVPDamageToOthersForXSecondsAfterLogin + " seconds after logging in.");
 			return false;
 		}
-		
+
 		Faction locFaction = Board.getFactionAt(new FLocation(attacker));
-		
+
 		// so we know from above that the defender isn't in a safezone... what about the attacker, sneaky dog that he might be?
 		if (locFaction.getFlag(FFlag.PVP) == false)
 		{
 			attacker.msg("<i>PVP is disabled in %s.", locFaction.describeTo(attacker));
 			return false;
 		}
-		
+
 		Faction defendFaction = defender.getFaction();
 		Faction attackFaction = attacker.getFaction();
-		
+
 		if (attackFaction.isNone() && Conf.disablePVPForFactionlessPlayers)
 		{
 			attacker.msg("<i>You can't hurt other players until you join a faction.");
@@ -195,16 +206,16 @@ public class FactionsEntityListener extends EntityListener
 				return false;
 			}
 		}
-		
+
 		Rel relation = defendFaction.getRelationTo(attackFaction);
-		
+
 		// Check the relation
 		if (relation.isAtLeast(Conf.friendlyFireFromRel) && defLocFaction.getFlag(FFlag.FRIENDLYFIRE) == false)
 		{
 			attacker.msg("<i>You can't hurt %s<i>.", relation.getDescPlayerMany());
 			return false;
 		}
-		
+
 		// You can not hurt neutrals in their own territory.
 		boolean ownTerritory = defender.isInOwnTerritory();
 		if (defender.hasFaction() && ownTerritory && relation == Rel.NEUTRAL)
@@ -213,53 +224,53 @@ public class FactionsEntityListener extends EntityListener
 			defender.msg("%s<i> tried to hurt you.", attacker.describeTo(defender, true));
 			return false;
 		}
-		
+
 		// Damage will be dealt. However check if the damage should be reduced.
 		if (ownTerritory && Conf.territoryShieldFactor > 0)
 		{
 			int newDamage = (int)Math.ceil(damage * (1D - Conf.territoryShieldFactor));
 			sub.setDamage(newDamage);
-			
+
 			// Send message
-		    String perc = MessageFormat.format("{0,number,#%}", (Conf.territoryShieldFactor)); // TODO does this display correctly??
-		    defender.msg("<i>Enemy damage reduced by <rose>%s<i>.", perc);
+			String perc = MessageFormat.format("{0,number,#%}", (Conf.territoryShieldFactor)); // TODO does this display correctly??
+			defender.msg("<i>Enemy damage reduced by <rose>%s<i>.", perc);
 		}
-		
+
 		return true;
 	}
-	
+
 	@Override
 	public void onCreatureSpawn(CreatureSpawnEvent event)
 	{
 		if (event.isCancelled()) return;
 		if (event.getLocation() == null) return;
-		
+
 		FLocation floc = new FLocation(event.getLocation());
 		Faction faction = Board.getFactionAt(floc);
-		
+
 		if (faction.getFlag(FFlag.MONSTERS)) return;
 		if ( ! Conf.monsters.contains(event.getCreatureType())) return;
-		
+
 		event.setCancelled(true);
 	}
-	
+
 	@Override
 	public void onEntityTarget(EntityTargetEvent event)
 	{
 		if (event.isCancelled()) return;
-		
+
 		// if there is a target
 		Entity target = event.getTarget();
 		if (target == null) return;
-		
+
 		// We are interested in blocking targeting for certain mobs:
 		if ( ! Conf.monsters.contains(MiscUtil.creatureTypeFromEntity(event.getEntity()))) return;
-		
+
 		FLocation floc = new FLocation(target.getLocation());
 		Faction faction = Board.getFactionAt(floc);
-		
+
 		if (faction.getFlag(FFlag.MONSTERS)) return;
-		
+
 		event.setCancelled(true);
 	}
 
@@ -267,7 +278,7 @@ public class FactionsEntityListener extends EntityListener
 	public void onPaintingBreak(PaintingBreakEvent event)
 	{
 		if (event.isCancelled()) return;
-		
+
 		if (! (event instanceof PaintingBreakByEntityEvent))
 		{
 			return;
@@ -303,9 +314,9 @@ public class FactionsEntityListener extends EntityListener
 
 		FLocation floc = new FLocation(event.getBlock());
 		Faction faction = Board.getFactionAt(floc);
-		
+
 		if (faction.getFlag(FFlag.ENDERGRIEF)) return;
-		
+
 		event.setCancelled(true);
 	}
 
@@ -316,9 +327,9 @@ public class FactionsEntityListener extends EntityListener
 
 		FLocation floc = new FLocation(event.getLocation());
 		Faction faction = Board.getFactionAt(floc);
-		
+
 		if (faction.getFlag(FFlag.ENDERGRIEF)) return;
-		
+
 		event.setCancelled(true);
 	}
 }


### PR DESCRIPTION
Both are configurable in 'conf.json'.
PvP death : killed by another player
PvE : all others deaths, from lava to mobs
