### PR TITLE
Power regeneration rate increase as power decreases

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -34,6 +34,8 @@ public class Conf
 	public static double powerPlayerMin = -10.0;
 	public static double powerPerMinute = 0.2; // Default health rate... it takes 5 min to heal one power
 	public static double powerPerDeath = 4.0; // A death makes you lose 4 power
+	public static boolean scaleNegativePower = false; // Power regeneration rate increase as power decreases
+	public static double scaleNegativeDivisor = 40.0; // Divisor for inverse power regeneration curve    
 	public static boolean powerRegenOffline = false;  // does player power regenerate even while they're offline?
 	public static double powerOfflineLossPerDay = 0.0;  // players will lose this much power per day offline
 	public static double powerOfflineLossLimit = 0.0;  // players will no longer lose power from being offline once their power drops to this amount or less

--- a/src/com/massivecraft/factions/FPlayer.java
+++ b/src/com/massivecraft/factions/FPlayer.java
@@ -377,9 +377,15 @@ public class FPlayer extends PlayerEntity implements EconomyParticipator
 		long now = System.currentTimeMillis();
 		long millisPassed = now - this.lastPowerUpdateTime;
 		this.lastPowerUpdateTime = now;
+
+		int millisPerMinute = 60*1000;		
+		double powerPerMinute = Conf.powerPerMinute;
+		if(Conf.scaleNegativePower && this.power < 0)
+		{
+			powerPerMinute += (Math.sqrt(Math.abs(this.power)) * Math.abs(this.power)) / Conf.scaleNegativeDivisor;
+		}
+		this.alterPower(millisPassed * powerPerMinute / millisPerMinute);
 		
-		int millisPerMinute = 60*1000;
-		this.alterPower(millisPassed * Conf.powerPerMinute / millisPerMinute);
 	}
 
 	protected void losePowerFromBeingOffline()


### PR DESCRIPTION
We have a problem on our server wherein people who have been stomped to max negative power end up AFKing for extended periods of time (only to die again) or just leave the server. While increasing the powerPerMinute conf would solve this problem, it would also mean deaths above 0 power would go unpunished.

This solution allows us the best of both worlds and scales well with custom power values. e.g.
powerPerMin = 0.25
scaleNegativeDivisor = 30.0

<table>
    <tr>
        <th>Power</td>
        <th>powerPerMinute</td>
    </tr>
 <tr><td>0</td><td>0.25</td></tr>
<tr><td>-1</td><td>0.283333333333</td></tr>
<tr><td>-2</td><td>0.344280904158</td></tr>
<tr><td>-3</td><td>0.423205080757</td></tr>
<tr><td>-4</td><td>0.516666666667</td></tr>
<tr><td>-5</td><td>0.62267799625</td></tr>
<tr><td>-6</td><td>0.739897948557</td></tr>
<tr><td>-7</td><td>0.867341972582</td></tr>
<tr><td>-8</td><td>1.00424723327</td></tr>
<tr><td>-9</td><td>1.15</td></tr>
<tr><td>-10</td><td>1.30409255339</td></tr>
<tr><td>-11</td><td>1.46609575646</td></tr>
<tr><td>-12</td><td>1.63564064606</td></tr>
<tr><td>-13</td><td>1.8124055527</td></tr>
<tr><td>-14</td><td>1.99610678049</td></tr>
<tr><td>-15</td><td>2.1864916731</td></tr>
<tr><td>-16</td><td>2.38333333333</td></tr>
<tr><td>-17</td><td>2.58642652118</td></tr>
<tr><td>-18</td><td>2.79558441227</td></tr>
<tr><td>-19</td><td>3.01063599758</td></tr>
<tr><td>-20</td><td>3.23142397</td></tr>
</table>
