### PR TITLE
Fixes an ender pearl clipping exploit with blocks that occupy less than 1 block in width or length

### DIFF
--- a/src/com/massivecraft/factions/listeners/FactionsExploitListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsExploitListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener; 
 import org.bukkit.Location;
+import org.bukkit.Material;
 
 import com.massivecraft.factions.Conf;
 
@@ -38,5 +39,28 @@ public class FactionsExploitListener implements Listener
 		target.setX(target.getBlockX() + 0.5);
 		target.setZ(target.getBlockZ() + 0.5);
 		event.setTo(target);
+		
+		// this exploit allows players to clip through blocks who occupy less than 1 block width or length wise
+		Location from = event.getFrom();
+        if(event.getTo().getBlock().getType() == Material.THIN_GLASS || event.getTo().getBlock().getType() == Material.IRON_FENCE){            
+            if((from.getX() > target.getX() && (from.getX() - target.getX()) < 0.65) || (target.getX() > from.getX() && (target.getX() - from.getX() < 0.65))){
+                event.setTo(from);
+                return;
+            }
+            if((from.getZ() > target.getZ() && (from.getZ() - target.getZ()) < 0.65) || (target.getZ() > from.getZ() && (target.getZ() - from.getZ() < 0.65))){
+                event.setTo(from);
+                return;
+            }
+        }
+        if(event.getTo().getBlock().getType() == Material.FENCE || event.getTo().getBlock().getType() == Material.NETHER_FENCE){            
+            if((from.getX() > target.getX() && (from.getX() - target.getX()) < 0.45) || (target.getX() > from.getX() && (target.getX() - from.getX() < 0.45))){
+                event.setTo(from);
+                return;
+            }
+            if((from.getZ() > target.getZ() && (from.getZ() - target.getZ()) < 0.45) || (target.getZ() > from.getZ() && (target.getZ() - from.getZ() < 0.45))){
+                event.setTo(from);
+                return;
+            }
+        }
 	}
 }


### PR DESCRIPTION
After quite a bit of thorough testing, this seems to be an efficient way of fixing an exploit allowing people to go through blocks that are less than 1 block in length or width most importantly, glass panes, which are often used as windows. I'd be happy to pm you the re-creation conditions for the exploit. I know the setTo might seem a bit scary but from the extensive testing we did it causes almost no visible difference then what ender pearling into a solid block would be like.
