### PR TITLE
Removed spammy "boardclearat / clearclaim" message

### DIFF
--- a/src/com/massivecraft/factions/Faction.java
+++ b/src/com/massivecraft/factions/Faction.java
@@ -542,7 +542,6 @@ public class Faction extends Entity implements EconomyParticipator
 		if(Conf.onUnclaimResetLwcLocks && LWCFeatures.getEnabled())
 		{
 			LWCFeatures.clearAllChests(loc);
-			Bukkit.getServer().broadcastMessage("boardclearat / clearclaim");
 		}	
 		claimOwnership.remove(loc);
 	}


### PR DESCRIPTION
Pretty straightforward. Factions broadcasted pointless message whenever LWC locks were reset.
