### PR TITLE
Protecting Beacon and Anvil use by default and protecting Hanging entities from explosions

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -309,6 +309,8 @@ public class Conf
 		territoryProtectedMaterials.add(Material.ENCHANTMENT_TABLE);
 		territoryProtectedMaterials.add(Material.CAULDRON);
 		territoryProtectedMaterials.add(Material.SOIL);
+		territoryProtectedMaterials.add(Material.BEACON);
+		territoryProtectedMaterials.add(Material.ANVIL);
 
 		territoryDenyUseageMaterials.add(Material.FIREBALL);
 		territoryDenyUseageMaterials.add(Material.FLINT_AND_STEEL);
@@ -330,6 +332,8 @@ public class Conf
 		territoryProtectedMaterialsWhenOffline.add(Material.ENCHANTMENT_TABLE);
 		territoryProtectedMaterialsWhenOffline.add(Material.CAULDRON);
 		territoryProtectedMaterialsWhenOffline.add(Material.SOIL);
+		territoryProtectedMaterialsWhenOffline.add(Material.BEACON);
+		territoryProtectedMaterialsWhenOffline.add(Material.ANVIL);
 
 		territoryDenyUseageMaterialsWhenOffline.add(Material.FIREBALL);
 		territoryDenyUseageMaterialsWhenOffline.add(Material.FLINT_AND_STEEL);


### PR DESCRIPTION
Protect beacon and anvil use by default. This is pretty straightforward.

Protecting Hanging entities from explosions—painting explosion protection was never a feature in Factions, but it is especially important in 1.4.2 with the addition of item frames; someone can lure a creeper to an item frame and get whatever is inside which may be very valuable (e.g. a diamond in a frame to indicate a chest where diamonds are stored).

Unfortunately, Bukkit does not throw a HangingBreakByEntityEvent when it is destroyed by an explosion, so I've copied and pasted code from the onEntityExplode method to check if that location protects fireballs, creepers, or TNT. In other words, if any type of explosion is blocked at all in the territory, the Hanging entity will not be destroyed.
