### PR TITLE
Enemy territory can only be claimed at the corners.  No more bee lines straight to bases.

### DIFF
--- a/src/com/massivecraft/factions/Board.java
+++ b/src/com/massivecraft/factions/Board.java
@@ -95,16 +95,20 @@ public class Board
 		}
 	}
 
-	// Is this coord NOT completely surrounded by coords claimed by the same faction?
-	// Simpler: Is there any nearby coord with a faction other than the faction here?
-	public static boolean isBorderLocation(FLocation flocation)
+	//Is this coord on the corner of a factions territory
+	public static boolean isCornerLocation(FLocation flocation)
 	{
 		Faction faction = getFactionAt(flocation);
-		FLocation a = flocation.getRelative(1, 0);
-		FLocation b = flocation.getRelative(-1, 0);
-		FLocation c = flocation.getRelative(0, 1);
-		FLocation d = flocation.getRelative(0, -1);
-		return faction != getFactionAt(a) || faction != getFactionAt(b) || faction != getFactionAt(c) || faction != getFactionAt(d);
+		FLocation[] surrounds = new FLocation[8];   
+		surrounds[0] = flocation.getRelative( 1,  0);
+		surrounds[1] = flocation.getRelative(-1,  0);
+		surrounds[2] = flocation.getRelative( 0,  1);
+		surrounds[3] = flocation.getRelative( 0, -1);
+		int surroundCount = 0;
+		for (FLocation fl : surrounds) {
+			surroundCount += faction == getFactionAt(fl)?1:0;
+		}
+		return surroundCount < 3;
 	}
 
 	// Is this coord connected to any coord claimed by the specified faction?

--- a/src/com/massivecraft/factions/FPlayer.java
+++ b/src/com/massivecraft/factions/FPlayer.java
@@ -604,9 +604,9 @@ public class FPlayer extends PlayerEntity implements EconomyParticipator
 				 // TODO more messages WARN current faction most importantly
 				error = P.p.txt.parse("%s<i> owns this land and is strong enough to keep it.", currentFaction.getTag(this));
 			}
-			else if ( ! Board.isBorderLocation(flocation))
+			else if ( ! Board.isCornerLocation(flocation))
 			{
-				error = P.p.txt.parse("<b>You must start claiming land at the border of the territory.");
+				error = P.p.txt.parse("<b>You must start claiming land at the corner of the territory.");
 			}
 		}
 		


### PR DESCRIPTION
Implements the border check algorithm documented at:
https://docs.google.com/spreadsheet/ccc?key=0AtzhKJgvHXCKdFZvR1hWMXZJVjg1S2RtMUQ1eC1qR0E

May need to have a config to switch between classic style and corner style.

Above doc shows a couple of other border check algorithms as well.  See the sheet tabs at the bottom.

Edit:  This is running on `factions.aethercraft.com` if you want to try it out.
