### PR TITLE
Enemy presence reverts vulnerable land.

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -237,6 +237,9 @@ public class Conf
 	public static double econCostTruce = 0.0;
 	public static double econCostNeutral = 0.0;
 	public static double econCostEnemy = 0.0;
+	public static int    econLandRewardTaskRunsEveryXMinutes = 20;
+	public static double econLandReward = 0.01;
+	public static double econLandRevertEnemyReward = 25.0;
 	
 	//Faction banks, to pay for land claiming and other costs instead of individuals paying for them
 	public static boolean bankEnabled = true;

--- a/src/com/massivecraft/factions/listeners/FactionsPlayerListener.java
+++ b/src/com/massivecraft/factions/listeners/FactionsPlayerListener.java
@@ -32,6 +32,7 @@ import com.massivecraft.factions.FPlayers;
 import com.massivecraft.factions.Faction;
 import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.P;
+import com.massivecraft.factions.integration.Econ;
 import com.massivecraft.factions.integration.SpoutFeatures;
 import com.massivecraft.factions.struct.FFlag;
 import com.massivecraft.factions.struct.FPerm;
@@ -135,25 +136,32 @@ public class FactionsPlayerListener implements Listener
 		{
 			me.attemptClaim(me.getAutoClaimFor(), event.getTo(), true);
 		}
-		//if enemy, is corner, and host is weak => unclaim chunk
+		// if enemy, is corner, and host is weak => revert plot
 		else if (Rel.ENEMY == me.getRelationTo(access.getHostFaction()) &&
-				Board.isCornerLocation(to) && 
-				hostFaction.hasLandInflation()
-				)
+				Board.isCornerLocation(to) &&
+				hostFaction.hasLandInflation())
 		{
+
+			Board.setFactionAt(Factions.i.getNone(), to);
+
+			double res = Econ.transferAwardMoney(hostFaction, me, Conf.econLandRevertEnemyReward, true, "for reverting enemy corner land.");
+			String rewardMessage = "";
+			if (!Double.isNaN(res))
+			{
+				rewardMessage = " and received $" + Econ.moneyString(Conf.econLandRevertEnemyReward) + " as a reward.";
+			}
 			Set<FPlayer> informTheseFPlayers = new HashSet<FPlayer>();
 			informTheseFPlayers.add(me);
 			informTheseFPlayers.addAll(hostFaction.getFPlayersWhereOnline(true));
 			for (FPlayer fp : informTheseFPlayers)
 			{
-				fp.msg("<h>%s<i>'s presence unclaimed land from <h>%s<i>.", me.describeTo(fp, true), hostFaction.describeTo(fp));
+				fp.msg("<h>%s<i> reverted corner land from <h>%s<i>%s.", me.describeTo(fp, true), hostFaction.describeTo(fp), rewardMessage);
 			}
-			
-			Board.setFactionAt(Factions.i.getNone(), to);
+
 			SpoutFeatures.updateTerritoryDisplayLoc(to);
 
 			if (Conf.logLandClaims)
-				P.p.log(me.getName()+"'s presence unclaimed land at ("+to.getCoordString()+") from: "+hostFaction.getTag());
+				P.p.log(me.getName() + " unclaimed corner land at (" + to.getCoordString() + ") from: " + hostFaction.getTag());
 		}
 	}
 


### PR DESCRIPTION
If a player moves onto enemy faction land and the enemy faction does not have enough power to keep it, the land is automatically reverted to wilderness.  The player is awarded money from the enemy faction for the reversion.

Edit:  This is running on `factions.aethercraft.com` if you want to try it out.
