### PR TITLE
Make radius first option on claim command

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -157,6 +157,7 @@ public class Conf
 
 	// if someone is doing a radius claim and the process fails to claim land this many times in a row, it will exit
 	public static int radiusClaimFailureLimit = 9;
+	public static int radiusClaimMax = 5;
 
 	//public static double considerFactionsReallyOfflineAfterXMinutes = 0.0;
 	

--- a/src/com/massivecraft/factions/cmd/CmdClaim.java
+++ b/src/com/massivecraft/factions/cmd/CmdClaim.java
@@ -16,8 +16,8 @@ public class CmdClaim extends FCommand
 		this.aliases.add("claim");
 		
 		//this.requiredArgs.add("");
-		this.optionalArgs.put("faction", "your");
 		this.optionalArgs.put("radius", "1");
+		this.optionalArgs.put("faction", "your");
 		
 		this.permission = Permission.CLAIM.node;
 		this.disableOnLock = true;
@@ -32,8 +32,13 @@ public class CmdClaim extends FCommand
 	public void perform()
 	{
 		// Read and validate input
-		final Faction forFaction = this.argAsFaction(0, myFaction);
-		int radius = this.argAsInt(1, 1);
+		int radius = this.argAsInt(0, 1);
+		final Faction forFaction = this.argAsFaction(1, myFaction);
+
+		if (radius > Conf.radiusClaimMax) {
+			msg("<b>Max radius is %s.", Conf.radiusClaimMax);
+			return;
+		}
 
 		if (radius < 1)
 		{


### PR DESCRIPTION
As faction name tends to be an admin only option, have radius come first so that a faction leader need not specify their own faction name to use the radius option.

Edit:  This is running on `factions.aethercraft.com` if you want to try it out.
