### PR TITLE
Land reward

### DIFF
--- a/src/com/massivecraft/factions/Conf.java
+++ b/src/com/massivecraft/factions/Conf.java
@@ -239,7 +239,8 @@ public class Conf
 	public static double econCostEnemy = 0.0;
 
 	public static int    econLandRewardTaskRunsEveryXMinutes = 20;
-	public static double econLandReward = 0.01;
+	public static double econLandReward = 0.03;
+	public static double econLandRevertEnemyReward = 25.0;
 	
 	//Faction banks, to pay for land claiming and other costs instead of individuals paying for them
 	public static boolean bankEnabled = true;

--- a/src/com/massivecraft/factions/Factions.java
+++ b/src/com/massivecraft/factions/Factions.java
@@ -263,6 +263,7 @@ public class Factions extends EntityCollection<Faction>
 
 	public void econLandRewardRoutine()
 	{
+		P.p.log("Running econLandRewardRoutine...");
 		for (Faction faction : this.get())
 		{
 			int landCount = faction.getLandRounded();
@@ -273,7 +274,7 @@ public class Factions extends EntityCollection<Faction>
 				double reward = Conf.econLandReward * landCount / playerCount;
 				for (FPlayer player : players)
 				{
-					Econ.modifyMoney(player, reward, "to own faction land plots", "for faction owning " + landCount + " plots divided among " + playerCount + " members");
+					Econ.modifyMoney(player, reward, "to own faction land", "for faction owning " + landCount + " land divided among " + playerCount + " member(s)");
 				}
 			}
 		}

--- a/src/com/massivecraft/factions/P.java
+++ b/src/com/massivecraft/factions/P.java
@@ -128,6 +128,9 @@ public class P extends MPlugin
 		// start up task which runs the autoLeaveAfterDaysOfInactivity routine
 		startAutoLeaveTask(false);
 
+		// start up task which runs the econLandRewardRoutine
+		startEconLandRewardTask(false);
+
 		// Register Event Handlers
 		getServer().getPluginManager().registerEvents(this.playerListener, this);
 		getServer().getPluginManager().registerEvents(this.chatListener, this);

--- a/src/com/massivecraft/factions/util/EconLandRewardTask.java
+++ b/src/com/massivecraft/factions/util/EconLandRewardTask.java
@@ -10,7 +10,7 @@ public class EconLandRewardTask implements Runnable {
 	
 	public EconLandRewardTask()
 	{
-		this.rate = Conf.autoLeaveRoutineRunsEveryXMinutes;
+		this.rate = Conf.econLandRewardTaskRunsEveryXMinutes;
 	}
 
 	@Override


### PR DESCRIPTION
Factions members are rewarded each minecraft day (20 mins) for the amount of land owned by the faction divided among all the members of the faction.

Edit:  This is running on `factions.aethercraft.com` if you want to try it out.
