### PR TITLE
Added more Spout label alignment options

### DIFF
--- a/src/com/massivecraft/factions/integration/SpoutMainListener.java
+++ b/src/com/massivecraft/factions/integration/SpoutMainListener.java
@@ -202,8 +202,8 @@ public class SpoutMainListener implements Listener
 		
 		if(labelHeight > SCREEN_HEIGHT)
 		{
-			label.setY(0);
-			return;
+				label.setY(0);
+				return;
 		}
 
 		switch (alignment)


### PR DESCRIPTION
This adds new values to the "spoutTerritoryDisplayPosition" option.

Previous values:
- 0 (Disabled)
- 1 (Top-left aligned)
- 2 (Top-center aligned)
- 3 (Top-right aligned)

New values:
- 0 (Disabled)
- 1 (Top-left aligned)
- 2 (Top-center aligned)
- 3 (Top-right aligned)
- 4 (Middle-left aligned)
- 5 (Middle-center aligned)
- 6 (Middle-right aligned)
- 7 (Bottom-left aligned)
- 8 (Bottom-center aligned)
- 9 (Bottom-right aligned)
