### PR TITLE
Allied territory cmddeny; AsyncChatEvent performance improvement

### DIFF
--- a/src/com/massivecraft/factions/ConfServer.java
+++ b/src/com/massivecraft/factions/ConfServer.java
@@ -66,6 +66,7 @@ public class ConfServer extends SimpleConfig
 	public static Set<String> permanentFactionMemberDenyCommands = new LinkedHashSet<String>();
 
 	// commands which will be prevented when in claimed territory of another faction
+	public static Set<String> territoryAllyDenyCommands = new LinkedHashSet<String>();
 	public static Set<String> territoryNeutralDenyCommands = new LinkedHashSet<String>();
 	public static Set<String> territoryEnemyDenyCommands = MUtil.set("home", "sethome", "spawn", "tpahere", "tpaccept", "tpa", "warp");
 	

--- a/src/com/massivecraft/factions/listeners/FactionsListenerChat.java
+++ b/src/com/massivecraft/factions/listeners/FactionsListenerChat.java
@@ -1,10 +1,11 @@
 package com.massivecraft.factions.listeners;
 
 import org.bukkit.Bukkit;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.plugin.EventExecutor;
 
 import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.chat.ChatFormatter;
@@ -16,124 +17,74 @@ public class FactionsListenerChat implements Listener
 	// -------------------------------------------- //
 	// INSTANCE & CONSTRUCT
 	// -------------------------------------------- //
-	
+
 	private static FactionsListenerChat i = new FactionsListenerChat();
 	public static FactionsListenerChat get() { return i; }
-	
-	// -------------------------------------------- //
-	// SETUP
-	// -------------------------------------------- //
-	
+
 	public void setup()
 	{
-		Bukkit.getPluginManager().registerEvents(this, Factions.get());
+		if (MConf.get().chatSetFormat) {
+			Bukkit.getPluginManager().registerEvent(AsyncPlayerChatEvent.class, this, MConf.get().chatSetFormatAt, new SetFormatEventExecutor(), Factions.get(), true);
+		}
+		if (MConf.get().chatParseTags) {
+			Bukkit.getPluginManager().registerEvent(AsyncPlayerChatEvent.class, this, MConf.get().chatParseTagsAt, new ParseTagsEventExecutor(), Factions.get(), true);
+		}
 	}
-	
+
 	// -------------------------------------------- //
 	// SET FORMAT
 	// -------------------------------------------- //
-	
-	public static void setFormat(AsyncPlayerChatEvent event, EventPriority currentPriority)
+
+	private class SetFormatEventExecutor implements EventExecutor {
+		@Override
+		public void execute(Listener listener, Event event) throws EventException {
+			try {
+				if (!AsyncPlayerChatEvent.class.isAssignableFrom(event.getClass())) {
+					return;
+				}
+				setFormat((AsyncPlayerChatEvent)event);
+			} catch (Throwable t) {
+				throw new EventException(t);
+			}
+		}
+	}
+
+	public static void setFormat(AsyncPlayerChatEvent event)
 	{
 		// If we are setting the chat format ...
 		if (!MConf.get().chatSetFormat) return;
-		
-		// ... and this is the right priority ...
-		if (currentPriority != MConf.get().chatSetFormatAt) return;
-		
+
 		// ... then set the format.
 		event.setFormat(MConf.get().chatSetFormatTo);
 	}
-	
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void setFormatLowest(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.LOWEST);
-	}
-	
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	public void setFormatLow(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.LOW);
-	}
-	
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-	public void setFormatNormal(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.NORMAL);
-	}
-	
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-	public void setFormatHigh(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.HIGH);
-	}
-	
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void setFormatHighest(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.HIGHEST);
-	}
-	
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void setFormatMonitor(AsyncPlayerChatEvent event)
-	{
-		setFormat(event, EventPriority.MONITOR);
-	}
-	
+
 	// -------------------------------------------- //
 	// PARSE TAGS
 	// -------------------------------------------- //
-	
-	public static void parseTags(AsyncPlayerChatEvent event, EventPriority currentPriority)
+
+	private class ParseTagsEventExecutor implements EventExecutor {
+		@Override
+		public void execute(Listener listener, Event event) throws EventException {
+			try {
+				if (!AsyncPlayerChatEvent.class.isAssignableFrom(event.getClass())) {
+					return;
+				}
+				parseTags((AsyncPlayerChatEvent)event);
+			} catch (Throwable t) {
+				throw new EventException(t);
+			}
+		}
+	}
+
+	public static void parseTags(AsyncPlayerChatEvent event)
 	{
 		// If we are setting the chat format ...
 		if (!MConf.get().chatParseTags) return;
-		
-		// ... and this is the right priority ...
-		if (currentPriority != MConf.get().chatParseTagsAt) return;
-		
+
 		// ... then parse tags a.k.a. "format the format".
 		String format = event.getFormat();
-		
+
 		format = ChatFormatter.format(format, UPlayer.get(event.getPlayer()), null);
 		event.setFormat(format);
 	}
-	
-	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-	public void parseTagsLowest(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.LOWEST);
-	}
-	
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-	public void parseTagsLow(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.LOW);
-	}
-	
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-	public void parseTagsNormal(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.NORMAL);
-	}
-	
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-	public void parseTagsHigh(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.HIGH);
-	}
-	
-	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void parseTagsHighest(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.HIGHEST);
-	}
-	
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void parseTagsMonitor(AsyncPlayerChatEvent event)
-	{
-		parseTags(event, EventPriority.MONITOR);
-	}
-	
 }

--- a/src/com/massivecraft/factions/listeners/FactionsListenerMain.java
+++ b/src/com/massivecraft/factions/listeners/FactionsListenerMain.java
@@ -338,11 +338,9 @@ public class FactionsListenerMain implements Listener
 		
 		// ... clean up the command ...
 		String command = event.getMessage();
-		command = Txt.removeLeadingCommandDust(command);
-		command = command.toLowerCase();
-		command = command.trim();
-		
-		if (uplayer.hasFaction() && uplayer.getFaction().getFlag(FFlag.PERMANENT) && containsCommand(command, ConfServer.permanentFactionMemberDenyCommands))
+		command = Txt.removeLeadingCommandDust(command).toLowerCase().trim();
+
+		if ((!ConfServer.permanentFactionMemberDenyCommands.isEmpty()) && uplayer.hasFaction() && uplayer.getFaction().getFlag(FFlag.PERMANENT) && containsCommand(command, ConfServer.permanentFactionMemberDenyCommands))
 		{
 			uplayer.msg("<b>You can't use \"<h>/%s<b>\" as member of a permanent faction.", command);
 			event.setCancelled(true);
@@ -352,17 +350,24 @@ public class FactionsListenerMain implements Listener
 		Rel rel = uplayer.getRelationToLocation();
 		PS ps = PS.valueOf(player).getChunk(true);
 		if (BoardColls.get().getFactionAt(ps).isNone()) return;
-		
-		if (rel == Rel.NEUTRAL && containsCommand(command, ConfServer.territoryNeutralDenyCommands))
+
+		if ((!ConfServer.territoryEnemyDenyCommands.isEmpty()) && rel == Rel.ENEMY && containsCommand(command, ConfServer.territoryEnemyDenyCommands))
+		{
+			uplayer.msg("<b>You can't use \"<h>/%s<b>\" in enemy territory.", command);
+			event.setCancelled(true);
+			return;
+		}
+
+		if ((!ConfServer.territoryNeutralDenyCommands.isEmpty()) && rel == Rel.NEUTRAL && containsCommand(command, ConfServer.territoryNeutralDenyCommands))
 		{
 			uplayer.msg("<b>You can't use \"<h>/%s<b>\" in neutral territory.", command);
 			event.setCancelled(true);
 			return;
 		}
 
-		if (rel == Rel.ENEMY && containsCommand(command, ConfServer.territoryEnemyDenyCommands))
+		if ((!ConfServer.territoryAllyDenyCommands.isEmpty()) && rel == Rel.ALLY && containsCommand(command, ConfServer.territoryAllyDenyCommands))
 		{
-			uplayer.msg("<b>You can't use \"<h>/%s<b>\" in enemy territory.", command);
+			uplayer.msg("<b>You can't use \"<h>/%s<b>\" in allied territory.", command);
 			event.setCancelled(true);
 			return;
 		}


### PR DESCRIPTION
- Config option territoryAllyDenyCommands is added, similar to territoryNeutralDenyCommands.
- FactionsListenerChat, which does all the player format processing, is changed to use dynamic event priorities instead of ten event handlers. To do this, a private EventExecutor class is created, with the implementation (pretty much) copied from CraftBukkit.
- Additionally, PlayerCommandPreProcessEvent tries to short-circuit some checks, but actually analysing is needed to determine where the real performance losses are.
#224
