### PR TITLE
Cosmetic change

### DIFF
--- a/src/com/massivecraft/factions/struct/FPerm.java
+++ b/src/com/massivecraft/factions/struct/FPerm.java
@@ -25,7 +25,7 @@ import com.massivecraft.factions.iface.RelationParticipator;
 public enum FPerm
 {
 	BUILD("build", "edit the terrain",             Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY),
-	PAINBUILD("painbuild", "edit but take damage"),
+	PAINBUILD("painbuild", "edit, take damage"),
 	DOOR("door", "use doors",                      Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY),
 	BUTTON("button", "use stone buttons",          Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY),
 	LEVER("lever", "use levers",                   Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY),
@@ -36,7 +36,7 @@ public enum FPerm
 	WITHDRAW("withdraw", "withdraw money",         Rel.LEADER, Rel.OFFICER),
 	TERRITORY("territory", "claim or unclaim",     Rel.LEADER, Rel.OFFICER),
 	CAPE("cape", "set the cape",                   Rel.LEADER, Rel.OFFICER),
-	ACCESS("access", "grant territory access",     Rel.LEADER, Rel.OFFICER),
+	ACCESS("access", "grant territory",            Rel.LEADER, Rel.OFFICER),
 	DISBAND("disband", "disband the faction",      Rel.LEADER),
 	PERMS("perms", "manage permissions",           Rel.LEADER),
 	;


### PR DESCRIPTION
This makes it 1 line per perm, so Access & Painbuild do not create a 2nd line to finish the details. 
