### PR TITLE
new border check algos

### DIFF
--- a/src/com/massivecraft/factions/entity/Board.java
+++ b/src/com/massivecraft/factions/entity/Board.java
@@ -14,7 +14,6 @@ import org.bukkit.ChatColor;
 
 import com.massivecraft.factions.Const;
 import com.massivecraft.factions.Factions;
-import com.massivecraft.factions.Rel;
 import com.massivecraft.factions.RelationParticipator;
 import com.massivecraft.factions.TerritoryAccess;
 import com.massivecraft.factions.util.AsciiCompass;
@@ -349,59 +348,5 @@ public class Board extends Entity<Board> implements BoardInterface
 		UConf uConf = UConf.get(this);
 		BorderAlgo algo = uConf.claimsBorderAlgo != null ? uConf.claimsBorderAlgo : BorderAlgo.ORIGINAL;
 		return algo.isBorderPs(ps, this);
-	}
-
-	public static enum BorderAlgo {
-		ORIGINAL {
-			@Override
-			public boolean isBorderPs(PS ps, Board board) {
-				return board.isBorderPsOriginal(ps);
-			}
-		},
-		ORTHOGANAL_THREE {
-			@Override
-			public boolean isBorderPs(PS ps, Board board) {
-				Faction fac = board.getFactionAt(ps);
-				PS[] orthoganalPSes = new PS[]{
-					ps.withChunkX(ps.getChunkX() - 1),
-					ps.withChunkX(ps.getChunkX() + 1),
-					ps.withChunkZ(ps.getChunkZ() - 1),
-					ps.withChunkZ(ps.getChunkZ() + 1)
-				};
-				int orthoganalCount = 0;
-				for (PS psI : orthoganalPSes) {
-					if (Rel.MEMBER == board.getFactionAt(psI).getRelationTo(fac)) {
-						orthoganalCount ++;
-					}
-				}
-				return orthoganalCount < 3;
-			}
-		},
-		SURROUND_FIVE {
-			@Override
-			public boolean isBorderPs(PS ps, Board board) {
-				Faction fac = board.getFactionAt(ps);
-				PS psXSubOne = ps.withChunkX(ps.getChunkX() - 1);
-				PS psXAddOne = ps.withChunkX(ps.getChunkX() + 1);
-				PS[] surroundingPSes = new PS[]{
-					ps       .withChunkZ(ps.getChunkZ() - 1),
-					ps       .withChunkZ(ps.getChunkZ() + 1),
-					psXSubOne                               ,
-					psXSubOne.withChunkZ(ps.getChunkZ() - 1),
-					psXSubOne.withChunkZ(ps.getChunkZ() + 1),
-					psXAddOne                               ,
-					psXAddOne.withChunkZ(ps.getChunkZ() - 1),
-					psXAddOne.withChunkZ(ps.getChunkZ() + 1)
-				};
-				int surroundCount = 0;
-				for (PS psI : surroundingPSes) {
-					if (Rel.MEMBER == board.getFactionAt(psI).getRelationTo(fac)) {
-						surroundCount ++;
-					}
-				}
-				return surroundCount < 5;
-			}
-		};
-		abstract public boolean isBorderPs(PS ps, Board board);
 	}
 }

--- a/src/com/massivecraft/factions/entity/BorderAlgo.java
+++ b/src/com/massivecraft/factions/entity/BorderAlgo.java
@@ -1,0 +1,58 @@
+package com.massivecraft.factions.entity;
+
+import com.massivecraft.factions.Rel;
+import com.massivecraft.mcore.ps.PS;
+
+public enum BorderAlgo {
+	ORIGINAL {
+		@Override
+		public boolean isBorderPs(PS ps, Board board) {
+			return board.isBorderPsOriginal(ps);
+		}
+	},
+	ORTHOGANAL_THREE {
+		@Override
+		public boolean isBorderPs(PS ps, Board board) {
+			Faction fac = board.getFactionAt(ps);
+			PS[] orthoganalPSes = new PS[]{
+				ps.withChunkX(ps.getChunkX() - 1),
+				ps.withChunkX(ps.getChunkX() + 1),
+				ps.withChunkZ(ps.getChunkZ() - 1),
+				ps.withChunkZ(ps.getChunkZ() + 1)
+			};
+			int orthoganalCount = 0;
+			for (PS psI : orthoganalPSes) {
+				if (Rel.MEMBER == board.getFactionAt(psI).getRelationTo(fac)) {
+					orthoganalCount ++;
+				}
+			}
+			return orthoganalCount < 3;
+		}
+	},
+	SURROUND_FIVE {
+		@Override
+		public boolean isBorderPs(PS ps, Board board) {
+			Faction fac = board.getFactionAt(ps);
+			PS psXSubOne = ps.withChunkX(ps.getChunkX() - 1);
+			PS psXAddOne = ps.withChunkX(ps.getChunkX() + 1);
+			PS[] surroundingPSes = new PS[]{
+				ps       .withChunkZ(ps.getChunkZ() - 1),
+				ps       .withChunkZ(ps.getChunkZ() + 1),
+				psXSubOne                               ,
+				psXSubOne.withChunkZ(ps.getChunkZ() - 1),
+				psXSubOne.withChunkZ(ps.getChunkZ() + 1),
+				psXAddOne                               ,
+				psXAddOne.withChunkZ(ps.getChunkZ() - 1),
+				psXAddOne.withChunkZ(ps.getChunkZ() + 1)
+			};
+			int surroundCount = 0;
+			for (PS psI : surroundingPSes) {
+				if (Rel.MEMBER == board.getFactionAt(psI).getRelationTo(fac)) {
+					surroundCount ++;
+				}
+			}
+			return surroundCount < 5;
+		}
+	};
+	abstract public boolean isBorderPs(PS ps, Board board);
+}

--- a/src/com/massivecraft/factions/entity/UConf.java
+++ b/src/com/massivecraft/factions/entity/UConf.java
@@ -11,7 +11,6 @@ import org.bukkit.command.CommandSender;
 import com.massivecraft.factions.FFlag;
 import com.massivecraft.factions.FPerm;
 import com.massivecraft.factions.Rel;
-import com.massivecraft.factions.entity.Board;
 import com.massivecraft.factions.event.FactionsEventChunkChangeType;
 import com.massivecraft.mcore.store.Entity;
 import com.massivecraft.mcore.store.SenderEntity;
@@ -115,8 +114,7 @@ public class UConf extends Entity<UConf>
 	public int claimsRequireMinFactionMembers = 1;
 	public int claimedLandsMax = 0;
 	
-	public String claimsBorderAlgoName = "ORIGINAL";
-	public Board.BorderAlgo claimsBorderAlgo = Board.BorderAlgo.valueOf(claimsBorderAlgoName);
+	public BorderAlgo claimsBorderAlgo = BorderAlgo.ORIGINAL;
 
 	// -------------------------------------------- //
 	// HOMES


### PR DESCRIPTION
redux of https://github.com/MassiveCraft/Factions/pull/190

ORIGINAL - allows for bee lines to center of territory
[ORTHOGANAL_THREE](https://docs.google.com/spreadsheet/ccc?key=0AtzhKJgvHXCKdFZvR1hWMXZJVjg1S2RtMUQ1eC1qR0E#gid=0)
[SURROUND_FIVE](https://docs.google.com/spreadsheet/ccc?key=0AtzhKJgvHXCKdFZvR1hWMXZJVjg1S2RtMUQ1eC1qR0E#gid=3)

You'll have to ignore the travis build failure below until you accept my [gradle pull request](https://github.com/MassiveCraft/mcore/pull/9) on MCore and the [gradle pull request](https://github.com/MassiveCraft/Factions/pull/245) here

Along with the the corresponding .travis.yml files from my forks.

SURROUND_FIVE is currently running on `llamacraft.com`.  Feel free to go there and test it out.
