### PR TITLE
Fix chunk change event bug

### DIFF
--- a/src/com/massivecraft/factions/event/FactionsEventChunkChange.java
+++ b/src/com/massivecraft/factions/event/FactionsEventChunkChange.java
@@ -25,7 +25,7 @@ public class FactionsEventChunkChange extends FactionsEventAbstractSender
 	private final PS chunk;
 	public PS getChunk() { return this.chunk; }
 	
-    private final Faction currentFaction;
+	private final Faction currentFaction;
 	private final Faction newFaction;
 	public Faction getNewFaction() { return this.newFaction; }
 	
@@ -37,7 +37,7 @@ public class FactionsEventChunkChange extends FactionsEventAbstractSender
 	{
 		super(sender);
 		this.chunk = chunk.getChunk(true);
-        this.currentFaction = BoardColls.get().getFactionAt(chunk);
+		this.currentFaction = BoardColls.get().getFactionAt(chunk);
 		this.newFaction = newFaction;
 	}
 	


### PR DESCRIPTION
tryClaim changes the board in between the time tryClaim instantiates the event and tryClaim calls event.getType

https://github.com/MassiveCraft/Factions/blob/master/src/com/massivecraft/factions/entity/UPlayer.java#L766-L790
