### PR TITLE
Update getMin to use powerboosts

### DIFF
--- a/src/com/massivecraft/factions/mixin/PowerMixinDefault.java
+++ b/src/com/massivecraft/factions/mixin/PowerMixinDefault.java
@@ -31,7 +31,7 @@ public class PowerMixinDefault implements PowerMixin
 	@Override
 	public double getMin(UPlayer uplayer)
 	{
-		return UConf.get(uplayer).powerMin;
+		return UConf.get(uplayer).powerMin - uplayer.getPowerBoost();
 	}
 
 	@Override


### PR DESCRIPTION
The players min power should also be adjusted to account for a players powerboost, just like their max power.
