### PR TITLE
Fix "The faction %s<i> was disbanded." colors

### DIFF
--- a/src/com/massivecraft/factions/entity/Faction.java
+++ b/src/com/massivecraft/factions/entity/Faction.java
@@ -990,7 +990,7 @@ public class Faction extends Entity<Faction> implements EconomyParticipator
 
 			for (UPlayer uplayer : UPlayerColls.get().get(this).getAllOnline())
 			{
-				uplayer.msg("The faction %s<i> was disbanded.", this.getName(uplayer));
+				uplayer.msg("<i>The faction %s<i> was disbanded.", this.getName(uplayer));
 			}
 
 			this.detach();


### PR DESCRIPTION
Fixes "The faction %s< i> was disbanded." colors, happens when an faction is disbanded because of no players left.
"The faction %s< i> was disbanded." --> "< i>The faction %s< i> was disbanded."
