### PR TITLE
Fix EventChunkChange.getUSender() returning null after a server reload

### DIFF
--- a/src/com/massivecraft/factions/entity/UPlayer.java
+++ b/src/com/massivecraft/factions/entity/UPlayer.java
@@ -765,7 +765,7 @@ public class UPlayer extends SenderEntity<UPlayer> implements EconomyParticipato
 		}
 		
 		// Event
-		FactionsEventChunkChange event = new FactionsEventChunkChange(sender, chunk, newFaction);
+		FactionsEventChunkChange event = new FactionsEventChunkChange(this.getSender(), chunk, newFaction);
 		event.run();
 		if (event.isCancelled()) return false;
 


### PR DESCRIPTION
When performing a reload, the "sender" field is null in the UPlayer class.
Using MCore's SenderEntity.getSender() method, it will re-initialize the field.
This will avoid invalid events from being passed to other plugins.
Factions itself displays 'pillage' instead of 'sell' in that case.

Screenshot demonstrating the issue:

![2014-05-06_00 32 40](https://cloud.githubusercontent.com/assets/1128206/2884164/1599ffdc-d4a6-11e3-8814-26474bb1f9d7.png)

After the server reload, my plugin does not handle the event because it gets a NullPointerException.

Thanks for your work on the Factions plugin. This is only a modest contribution :)
