### PR TITLE
Fixed factions_rollprefixforce 

### DIFF
--- a/src/main/java/com/massivecraft/factions/chat/tag/ChatTagRoleprefixforce.java
+++ b/src/main/java/com/massivecraft/factions/chat/tag/ChatTagRoleprefixforce.java
@@ -11,7 +11,7 @@ public class ChatTagRoleprefixforce extends ChatTagAbstract
 	// INSTANCE & CONSTRUCT
 	// -------------------------------------------- //
 	
-	private ChatTagRoleprefixforce() { super("factions_roleprefix"); }
+	private ChatTagRoleprefixforce() { super("factions_roleprefixforce"); }
 	private static ChatTagRoleprefixforce i = new ChatTagRoleprefixforce();
 	public static ChatTagRoleprefixforce get() { return i; }
 	


### PR DESCRIPTION
Was not being recognized as a valid chat tag, and would print {factions_rollprefixforce}. Fixed the typo.