### PR TITLE
Fix for kicking bug

### DIFF
--- a/src/com/massivecraft/factions/cmd/CmdFactionsKick.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsKick.java
@@ -57,7 +57,7 @@ public class CmdFactionsKick extends FactionsCommand
 			return;
 		}
 
-		if ( ! MConf.get().canLeaveWithNegativePower && mplayer.getPower() < 0)
+		if ( ! MConf.get().canLeaveWithNegativePower && mplayer.getPower() < 0 && ! msender.isUsingAdminMode())
 		{
 			msg("<b>You cannot kick that member until their power is positive.");
 			return;


### PR DESCRIPTION
This resolves the bug that you can't kick player with negativ power even if adminmode is on.
resolves:
https://github.com/MassiveCraft/Factions/issues/801