### PR TITLE
Add an event for when a faction's perms change.

### DIFF
--- a/src/com/massivecraft/factions/cmd/CmdFactionsPermSet.java
+++ b/src/com/massivecraft/factions/cmd/CmdFactionsPermSet.java
@@ -11,6 +11,7 @@ import com.massivecraft.factions.cmd.type.TypeRel;
 import com.massivecraft.factions.entity.Faction;
 import com.massivecraft.factions.entity.MPerm;
 import com.massivecraft.factions.entity.MPlayer;
+import com.massivecraft.factions.event.EventFactionsPermChange;
 import com.massivecraft.massivecore.MassiveException;
 import com.massivecraft.massivecore.command.requirement.RequirementHasPerm;
 import com.massivecraft.massivecore.command.type.primitive.TypeBoolean;
@@ -59,6 +60,12 @@ public class CmdFactionsPermSet extends FactionsCommand
 			msg("<b>The perm <h>%s <b>is not editable.", perm.getName());
 			return;
 		}
+		
+		// Event
+		EventFactionsPermChange event = new EventFactionsPermChange(sender, faction, perm, rel, value);
+		event.run();
+		if (event.isCancelled()) return;
+		value = event.getNewValue();
 		
 		// No change
 		if (faction.getPermitted(perm).contains(rel) == value)

--- a/src/com/massivecraft/factions/event/EventFactionsPermChange.java
+++ b/src/com/massivecraft/factions/event/EventFactionsPermChange.java
@@ -1,0 +1,50 @@
+package com.massivecraft.factions.event;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+
+import com.massivecraft.factions.Rel;
+import com.massivecraft.factions.entity.Faction;
+import com.massivecraft.factions.entity.MPerm;
+
+public class EventFactionsPermChange extends EventFactionsAbstractSender
+{	
+	// -------------------------------------------- //
+	// REQUIRED EVENT CODE
+	// -------------------------------------------- //
+	
+	private static final HandlerList handlers = new HandlerList();
+	@Override public HandlerList getHandlers() { return handlers; }
+	public static HandlerList getHandlerList() { return handlers; }
+	
+	// -------------------------------------------- //
+	// FIELDS
+	// -------------------------------------------- //
+	
+	private final Faction faction;
+	public Faction getFaction() { return this.faction; }
+	
+	private final MPerm perm;
+	public MPerm getPerm() { return this.perm; }
+	
+	private final Rel rel;
+	public Rel getRel() { return this.rel; }
+	
+	private boolean newValue;
+	public boolean getNewValue() { return this.newValue; }
+	public void setNewValue(boolean newValue) { this.newValue = newValue; }
+	
+	// -------------------------------------------- //
+	// CONSTRUCT
+	// -------------------------------------------- //
+	
+	public EventFactionsPermChange(CommandSender sender, Faction faction, MPerm perm, Rel rel, boolean newValue)
+	{
+		super(sender);
+		this.faction = faction;
+		this.perm = perm;
+		this.rel = rel;
+		this.newValue = newValue;
+	}
+	
+}


### PR DESCRIPTION
This adds an event that fires when a faction's perms are changed using `/f perm set`.  