### PR TITLE
Check for zero money on faction disband

### DIFF
--- a/src/com/massivecraft/factions/engine/EngineEcon.java
+++ b/src/com/massivecraft/factions/engine/EngineEcon.java
@@ -93,6 +93,10 @@ public class EngineEcon extends EngineAbstract
 		Faction faction = event.getFaction();
 	
 		double amount = Money.get(faction);
+	
+		// Check that there is an amount
+		if (amount == 0) return;
+
 		String amountString = Money.format(amount);
 		
 		Econ.transferMoney(faction, mplayer, mplayer, amount, true);


### PR DESCRIPTION
The takeOnDisband method of EngineEcon now checks if the amount of money to be transferred to the player upon disbanding a faction is 0. If this is the case, the method exits. 

This will prevent unnecessary operations in transferring money to players (which could be expensive if the economy is hooked to a database, for example).