### PR TITLE
Change the Factions cauldron non-support message

### DIFF
--- a/src/com/massivecraft/factions/entity/MPlayer.java
+++ b/src/com/massivecraft/factions/entity/MPlayer.java
@@ -870,10 +870,10 @@ public class MPlayer extends SenderEntity<MPlayer> implements EconomyParticipato
 		if (sender == null)
 		{
 			msg("<b>ERROR: Your \"CommandSender Link\" has been severed.");
-			msg("<b>It's likely that you are using Cauldron.");
-			msg("<b>We do currently not support Cauldron.");
-			msg("<b>We would love to but lack time to develop support ourselves.");
-			msg("<g>Do you know how to code? Please send us a pull request <3, sorry.");
+			msg("<b>It's likely that you are using Cauldron, KCauldron or Thermos.");
+			msg("<b>We do not support forge-bukkit hybrid servers natively.");
+			msg("<b>MarkehMe (Author of FactionsPlus) has been kind enough to make an addon plugin to do this.");
+			msg("<g>Download it here: https://github.com/MarkehMe/MassiveCoreForgeFixes/releases.");
 			return false;
 		}
 		EventFactionsChunksChange event = new EventFactionsChunksChange(sender, chunks, newFaction);


### PR DESCRIPTION
Hey guys, mind if you change the message to inform Cauldron users of where to go to get their instance of Factions running?

@markehme and myself have fixed two of the issues which completely regains cauldron support (as of Factions 2.8.6).
