### PR TITLE
Fix Lingering Potion PvP Bug

### DIFF
--- a/src/com/massivecraft/factions/Factions.java
+++ b/src/com/massivecraft/factions/Factions.java
@@ -35,6 +35,7 @@ import com.massivecraft.factions.entity.MFlagColl;
 import com.massivecraft.factions.entity.MPermColl;
 import com.massivecraft.factions.entity.MPlayerColl;
 import com.massivecraft.factions.entity.MConfColl;
+import com.massivecraft.factions.integration.V19.IntegrationV19;
 import com.massivecraft.factions.integration.herochat.IntegrationHerochat;
 import com.massivecraft.factions.integration.lwc.IntegrationLwc;
 import com.massivecraft.factions.integration.spigot.IntegrationSpigot;
@@ -159,6 +160,7 @@ public class Factions extends MassivePlugin
 			IntegrationHerochat.class,
 			IntegrationLwc.class,
 			IntegrationWorldGuard.class,
+			IntegrationV19.class,
 			
 			// Spigot
 			IntegrationSpigot.class,

--- a/src/com/massivecraft/factions/integration/V19/EngineV19.java
+++ b/src/com/massivecraft/factions/integration/V19/EngineV19.java
@@ -1,0 +1,69 @@
+package com.massivecraft.factions.integration.V19;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.projectiles.ProjectileSource;
+
+import com.massivecraft.factions.Factions;
+import com.massivecraft.factions.engine.EngineCombat;
+import com.massivecraft.massivecore.Engine;
+import com.massivecraft.massivecore.MassivePlugin;
+import com.massivecraft.massivecore.util.MUtil;
+
+public class EngineV19 extends Engine
+{
+	// -------------------------------------------- //
+	// INSTANCE & CONSTRUCT
+	// -------------------------------------------- //
+
+	private static EngineV19 i = new EngineV19 ();
+	public static EngineV19 get() { return i; }
+
+	@Override
+	public MassivePlugin getActivePlugin()
+	{
+		return Factions.get();
+	}
+
+	// -------------------------------------------- //
+	// LISTENER
+	// -------------------------------------------- //
+
+	@SuppressWarnings("deprecation")
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void canCombatDamageHappen(AreaEffectCloudApplyEvent event)
+	{
+		// If a harmful potion effect cloud is present ...
+		if ( ! MUtil.isHarmfulPotion(event.getEntity().getBasePotionData().getType().getEffectType())) return;
+		
+		ProjectileSource projectileSource = event.getEntity().getSource();
+		if ( ! (projectileSource instanceof Entity)) return;
+		
+		Entity thrower = (Entity)projectileSource;
+		
+		// ... create a dummy list to avoid ConcurrentModificationException ...
+		List<LivingEntity> affectedList = new ArrayList<LivingEntity>();
+		
+		// ... then scan through affected entities to make sure they're all valid targets ...
+		for (LivingEntity affectedEntity : event.getAffectedEntities())
+		{
+			EntityDamageByEntityEvent sub = new EntityDamageByEntityEvent(thrower, affectedEntity, EntityDamageEvent.DamageCause.CUSTOM, 0D);
+			// Notification disabled due to the iterating nature of effect clouds.
+			if (EngineCombat.get().canCombatDamageHappen(sub, false)) continue;
+			
+			affectedList.add(affectedEntity);
+		}
+		
+		// finally, remove valid targets from the affected list. (Unlike splash potions, area effect cloud's affected entities list is mutable.)
+		event.getAffectedEntities().removeAll(affectedList);
+	}
+	
+}

--- a/src/com/massivecraft/factions/integration/V19/IntegrationV19.java
+++ b/src/com/massivecraft/factions/integration/V19/IntegrationV19.java
@@ -1,0 +1,31 @@
+package com.massivecraft.factions.integration.V19;
+
+import com.massivecraft.massivecore.Engine;
+import com.massivecraft.massivecore.Integration;
+
+public class IntegrationV19 extends Integration
+{
+	// -------------------------------------------- //
+	// INSTANCE & CONSTRUCT
+	// -------------------------------------------- //
+
+	private static IntegrationV19 i = new IntegrationV19();
+	public static IntegrationV19 get() { return i; }
+	private IntegrationV19()
+	{
+		this.setClassNames(
+			"org.bukkit.event.entity.AreaEffectCloudApplyEvent"
+		);
+	}
+
+	// -------------------------------------------- //
+	// OVERRIDE
+	// -------------------------------------------- //
+
+	@Override
+	public Engine getEngine()
+	{
+		return EngineV19.get();
+	}
+
+}


### PR DESCRIPTION
Added a new event to the EngineCombat.java that will prevent lingering
potions from affecting players where PvP is disallowed.