### PR TITLE
Trusted Perm

### DIFF
--- a/src/com/massivecraft/factions/engine/EngineMain.java
+++ b/src/com/massivecraft/factions/engine/EngineMain.java
@@ -1329,29 +1329,38 @@ public class EngineMain extends Engine
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void blockBuild(PlayerInteractEvent event)
 	{
-		// ... if it is a left click on block ...
-		if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
-		
-		// .. and the clicked block is not null ... 
-		if (event.getClickedBlock() == null) return;
+		if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.PHYSICAL) return; 
+		Block block = event.getClickedBlock();
+		Player player = event.getPlayer();
 		
 		Block potentialBlock = event.getClickedBlock().getRelative(BlockFace.UP, 1);
+
+		if (block == null) return;  // clicked in air, apparently
 		
-		// .. and the potential block is not null ... 
-		if (potentialBlock == null) return;
-		
-		// ... and we're only going to check for fire ... (checking everything else would be bad performance wise)
 		if (potentialBlock.getType() != Material.FIRE) return;
-		
-		// ... check if they can build ...
+
+		if ( ! canPlayerUseBlock(player, block, true))
+		{
+			event.setCancelled(true);
+			return;
+		}
+
+		if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
+
+		if ( ! playerTrustedCantBreak(player, PS.valueOf(block), event.getMaterial(), true))
+		{
+			event.setCancelled(true);
+			return;
+		}	
+		if ( ! playerCanUseItemHere(player, PS.valueOf(block), event.getMaterial(), true))
+		{
+			event.setCancelled(true);
+			return;
+		}
 		if (canPlayerBuildAt(event.getPlayer(), PS.valueOf(potentialBlock), true)) return;
-		
-		// ... nope, cancel it
 		event.setCancelled(true);
-		
-		// .. and compensate for client side prediction
 		event.getPlayer().sendBlockChange(potentialBlock.getLocation(), potentialBlock.getType(), potentialBlock.getState().getRawData());
-	}
+ 	}
 	
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void blockLiquidFlow(BlockFromToEvent event)
@@ -1436,6 +1445,12 @@ public class EngineMain extends Engine
 
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;  // only interested on right-clicks for below
 
+		if ( ! playerTrustedCantPlace(player, PS.valueOf(block), event.getMaterial(), true))
+		{
+			event.setCancelled(true);
+			return;
+		}
+		
 		if ( ! playerCanUseItemHere(player, PS.valueOf(block), event.getMaterial(), true))
 		{
 			event.setCancelled(true);
@@ -1472,11 +1487,43 @@ public class EngineMain extends Engine
 		Material material = block.getType();
 		
 		if (MConf.get().materialsEditOnInteract.contains(material) && ! MPerm.getPermBuild().has(me, ps, verboose)) return false;
+		if (MConf.get().materialsTrustedPlace.contains(material) && ! MPerm.getPermTrusted().has(me, ps, verboose)) return false;
+		if (MConf.get().materialsTrustedBreak.contains(material) && ! MPerm.getPermTrusted().has(me, ps, verboose)) return false;
 		if (MConf.get().materialsContainer.contains(material) && ! MPerm.getPermContainer().has(me, ps, verboose)) return false;
 		if (MConf.get().materialsDoor.contains(material) && ! MPerm.getPermDoor().has(me, ps, verboose)) return false;
 		if (material == Material.STONE_BUTTON && ! MPerm.getPermButton().has(me, ps, verboose)) return false;
 		if (material == Material.LEVER && ! MPerm.getPermLever().has(me, ps, verboose)) return false;
 		return true;
+	}
+
+	public static boolean playerTrustedCantBreak(Player player, PS ps, Material material, boolean verboose)
+	{
+		if (MUtil.isntPlayer(player)) return true;
+		
+		if ( ! MConf.get().materialsTrustedBreak.contains(material)) return true;
+		
+		String name = player.getName();
+		if (MConf.get().playersWhoBypassAllProtection.contains(name)) return true;
+
+		MPlayer mplayer = MPlayer.get(player);
+		if (mplayer.isOverriding()) return true;
+		
+		return MPerm.getPermTrusted().has(mplayer, ps, verboose);
+	}
+	
+	public static boolean playerTrustedCantPlace(Player player, PS ps, Material material, boolean verboose)
+	{
+		if (MUtil.isntPlayer(player)) return true;
+		
+		if ( ! MConf.get().materialsTrustedPlace.contains(material)) return true;
+		
+		String name = player.getName();
+		if (MConf.get().playersWhoBypassAllProtection.contains(name)) return true;
+
+		MPlayer mplayer = MPlayer.get(player);
+		if (mplayer.isOverriding()) return true;
+		
+		return MPerm.getPermTrusted().has(mplayer, ps, verboose);
 	}
 	
 	// This event will not fire for Minecraft 1.8 armor stands.

--- a/src/com/massivecraft/factions/engine/EngineMain.java
+++ b/src/com/massivecraft/factions/engine/EngineMain.java
@@ -1329,16 +1329,15 @@ public class EngineMain extends Engine
 	@EventHandler(priority = EventPriority.NORMAL)
 	public void blockBuild(PlayerInteractEvent event)
 	{
-		if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.PHYSICAL) return; 
+		if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.PHYSICAL) return;
+		
 		Block block = event.getClickedBlock();
 		Player player = event.getPlayer();
-		
-		Block potentialBlock = event.getClickedBlock().getRelative(BlockFace.UP, 1);
 
+		Block potentialBlock = event.getClickedBlock().getRelative(BlockFace.UP, 1);
+		
 		if (block == null) return;  // clicked in air, apparently
 		
-		if (potentialBlock.getType() != Material.FIRE) return;
-
 		if ( ! canPlayerUseBlock(player, block, true))
 		{
 			event.setCancelled(true);
@@ -1351,16 +1350,21 @@ public class EngineMain extends Engine
 		{
 			event.setCancelled(true);
 			return;
-		}	
+		}
+		
 		if ( ! playerCanUseItemHere(player, PS.valueOf(block), event.getMaterial(), true))
 		{
 			event.setCancelled(true);
 			return;
 		}
 		if (canPlayerBuildAt(event.getPlayer(), PS.valueOf(potentialBlock), true)) return;
-		event.setCancelled(true);
-		event.getPlayer().sendBlockChange(potentialBlock.getLocation(), potentialBlock.getType(), potentialBlock.getState().getRawData());
- 	}
+		
+		if (potentialBlock.getType() != Material.FIRE) return;
+		{
+			event.setCancelled(true);
+			event.getPlayer().sendBlockChange(potentialBlock.getLocation(), potentialBlock.getType(), potentialBlock.getState().getRawData());
+		}
+	}
 	
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void blockLiquidFlow(BlockFromToEvent event)

--- a/src/com/massivecraft/factions/entity/FactionColl.java
+++ b/src/com/massivecraft/factions/entity/FactionColl.java
@@ -112,6 +112,7 @@ public class FactionColl extends Coll<Faction>
 		faction.setFlag(MFlag.getFlagZombiegrief(), true);
 		
 		faction.setPermittedRelations(MPerm.getPermBuild(), Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY);
+		faction.setPermittedRelations(MPerm.getPermTrusted(), Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY);
 		faction.setPermittedRelations(MPerm.getPermDoor(), Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY);
 		faction.setPermittedRelations(MPerm.getPermContainer(), Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY);
 		faction.setPermittedRelations(MPerm.getPermButton(), Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY);

--- a/src/com/massivecraft/factions/entity/MConf.java
+++ b/src/com/massivecraft/factions/entity/MConf.java
@@ -685,6 +685,25 @@ public class MConf extends Entity<MConf>
 		"WOLF", // Minecraft 1.?
 		"ZOMBIE_HORSE" // Minecraft 1.11
 	);
+	// List of blocks and items players without the trusted permission cannot place
+	public BackstringEnumSet<Material> materialsTrustedPlace = new BackstringEnumSet<Material>(Material.class,
+		"OBSIDIAN", // Minecraft 1.?
+		"TNT", // Minecraft 1.5
+		"MONSTER_EGG", // Minecraft 1.5
+		"FLINT_AND_STEEL", // Minecraft 1.5
+		"DISPENSER" // Minecraft 1.?
+	);
+		// List of blocks and items players without the trusted permission cannot break
+	public BackstringEnumSet<Material> materialsTrustedBreak = new BackstringEnumSet<Material>(Material.class,
+		"OBSIDIAN", // Minecraft 1.?
+		"FIRE", // Minecraft 1.?
+		"MOB_SPAWNER", // Minecraft 1.?
+		"TNT", // Minecraft 1.5
+		"MONSTER_EGG", // Minecraft 1.5
+		"FLINT_AND_STEEL", // Minecraft 1.5
+		"HOPPER", // Minecraft 1.?
+		"DISPENSER" // Minecraft 1.?
+	);
 	
 	// -------------------------------------------- //
 	// INTEGRATION: HeroChat

--- a/src/com/massivecraft/factions/entity/MPerm.java
+++ b/src/com/massivecraft/factions/entity/MPerm.java
@@ -29,6 +29,7 @@ public class MPerm extends Entity<MPerm> implements Prioritized, Registerable, N
 	// -------------------------------------------- //
 	
 	public final static transient String ID_BUILD = "build";
+	public final static transient String ID_TRUSTED = "trusted";
 	public final static transient String ID_PAINBUILD = "painbuild";
 	public final static transient String ID_DOOR = "door";
 	public final static transient String ID_BUTTON = "button";
@@ -55,6 +56,7 @@ public class MPerm extends Entity<MPerm> implements Prioritized, Registerable, N
 	public final static transient String ID_STATUS = "status";
 
 	public final static transient int PRIORITY_BUILD = 1000;
+	public final static transient int PRIORITY_TRUSTED = 1500;
 	public final static transient int PRIORITY_PAINBUILD = 2000;
 	public final static transient int PRIORITY_DOOR = 3000;
 	public final static transient int PRIORITY_BUTTON = 4000;
@@ -105,6 +107,7 @@ public class MPerm extends Entity<MPerm> implements Prioritized, Registerable, N
 	public static void setupStandardPerms()
 	{
 		getPermBuild();
+		getPermTrusted();
 		getPermPainbuild();
 		getPermDoor();
 		getPermButton();

--- a/src/com/massivecraft/factions/entity/MPerm.java
+++ b/src/com/massivecraft/factions/entity/MPerm.java
@@ -135,6 +135,7 @@ public class MPerm extends Entity<MPerm> implements Prioritized, Registerable, N
 	}
 	
 	public static MPerm getPermBuild() { return getCreative(PRIORITY_BUILD, ID_BUILD, ID_BUILD, "edit the terrain", MUtil.set(Rel.LEADER, Rel.OFFICER, Rel.MEMBER), true, true, true); }
+	public static MPerm getPermTrusted() { return getCreative(PRIORITY_TRUSTED, ID_TRUSTED, ID_TRUSTED, "perform trusted actions", MUtil.set(Rel.LEADER, Rel.OFFICER, Rel.TRUCE, Rel.NEUTRAL, Rel.ENEMY), true, false, true); }
 	public static MPerm getPermPainbuild() { return getCreative(PRIORITY_PAINBUILD, ID_PAINBUILD, ID_PAINBUILD, "edit, take damage", new LinkedHashSet<Rel>(), true, true, true); }
 	public static MPerm getPermDoor() { return getCreative(PRIORITY_DOOR, ID_DOOR, ID_DOOR, "use doors", MUtil.set(Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY), true, true, true); }
 	public static MPerm getPermButton() { return getCreative(PRIORITY_BUTTON, ID_BUTTON, ID_BUTTON, "use stone buttons", MUtil.set(Rel.LEADER, Rel.OFFICER, Rel.MEMBER, Rel.RECRUIT, Rel.ALLY), true, true, true); }


### PR DESCRIPTION
I've seen this on various servers as a means to further prevent betrayal.

This permissions makes it so:
- Those without it cannot place certain blocks/items (creeper egg) that are listed in mconf
- Those without it cannot break certain blocks that are listed in mconf

By default I made it so everyone besides ally/recruit/member has the permission otherwise enemies/neutrals/truces wouldn't be able to place creeper eggs