### PR TITLE
Adding a new option "territoryInfoChatsDefault"

### DIFF
--- a/src/com/massivecraft/factions/engine/EngineMoveChunk.java
+++ b/src/com/massivecraft/factions/engine/EngineMoveChunk.java
@@ -74,12 +74,11 @@ public class EngineMoveChunk extends Engine
 				String maintitle = parseTerritoryInfo(MConf.get().territoryInfoTitlesMain, mplayer, factionTo);
 				String subtitle = parseTerritoryInfo(MConf.get().territoryInfoTitlesSub, mplayer, factionTo);
 				MixinTitle.get().sendTitleMessage(player, MConf.get().territoryInfoTitlesTicksIn, MConf.get().territoryInfoTitlesTicksStay, MConf.get().territoryInfoTitleTicksOut, maintitle, subtitle);
-			}
-			else
-			{
+			} else if (mplayer.isTerritoryInfoChats()) {
 				String message = parseTerritoryInfo(MConf.get().territoryInfoChat, mplayer, factionTo);
 				player.sendMessage(message);
 			}
+			//NO information is the two boolean is false !
 		}
 
 		// Show access level message if it changed.

--- a/src/com/massivecraft/factions/entity/MConf.java
+++ b/src/com/massivecraft/factions/entity/MConf.java
@@ -290,7 +290,8 @@ public class MConf extends Entity<MConf>
 	// -------------------------------------------- //
 	
 	public boolean territoryInfoTitlesDefault = true;
-
+	public boolean territoryInfoChatsDefault = false;
+	
 	public String territoryInfoTitlesMain = "{relcolor}{name}";
 	public String territoryInfoTitlesSub = "<i>{desc}";
 	public int territoryInfoTitlesTicksIn = 5;

--- a/src/com/massivecraft/factions/entity/MPlayer.java
+++ b/src/com/massivecraft/factions/entity/MPlayer.java
@@ -61,7 +61,8 @@ public class MPlayer extends SenderEntity<MPlayer> implements FactionsParticipat
 		this.setMapAutoUpdating(that.mapAutoUpdating);
 		this.setOverriding(that.overriding);
 		this.setTerritoryInfoTitles(that.territoryInfoTitles);
-
+		this.setTerritoryInfoChats(that.territoryInfoChats);
+		
 		return this;
 	}
 
@@ -81,7 +82,7 @@ public class MPlayer extends SenderEntity<MPlayer> implements FactionsParticipat
 		// if (this.isMapAutoUpdating()) return false; // Just having an auto updating map is not in itself reason enough for database storage.
 		if (this.isOverriding()) return false;
 		if (this.isTerritoryInfoTitles() != MConf.get().territoryInfoTitlesDefault) return false;
-
+		if (this.isTerritoryInfoChats() != MConf.get().territoryInfoChatsDefault) return false;
 		return true;
 	}
 
@@ -600,6 +601,30 @@ public class MPlayer extends SenderEntity<MPlayer> implements FactionsParticipat
 
 		// Apply
 		this.territoryInfoTitles = target;
+
+		// Mark as changed
+		this.changed();
+	}
+	
+	
+	public boolean isTerritoryInfoChats()
+	{
+		if (!MixinTitle.get().isAvailable()) return false;
+		if (this.territoryInfoChats == null) return MConf.get().territoryInfoChatsDefault;
+		return this.territoryInfoChats;
+	}
+
+	public void setTerritoryInfoChats(Boolean territoryInfoChats)
+	{
+		// Clean input
+		Boolean target = territoryInfoChats;
+		if (MUtil.equals(target, MConf.get().territoryInfoChatsDefault)) target = null;
+
+		// Detect Nochange
+		if (MUtil.equals(this.territoryInfoChats, target)) return;
+
+		// Apply
+		this.territoryInfoChats = target;
 
 		// Mark as changed
 		this.changed();

--- a/src/com/massivecraft/factions/entity/MPlayer.java
+++ b/src/com/massivecraft/factions/entity/MPlayer.java
@@ -188,6 +188,8 @@ public class MPlayer extends SenderEntity<MPlayer> implements FactionsParticipat
 	// Null means default specified in MConf.
 	private Boolean territoryInfoTitles = null;
 
+	private Boolean territoryInfoChats = null;
+
 	// The id for the faction this player is currently autoclaiming for.
 	// Null means the player isn't auto claiming.
 	// NOTE: This field will not be saved to the database ever.


### PR DESCRIPTION
This a option to disable all territoryInfo if "territoryInfoTitlesDefault" equals false no title and "territoryInfoChatsDefault" no message if "territoryInfoChatsDefault" equals true a message has be send to player