### PR TITLE
Remove WorldGuard Integration Errror

### DIFF
--- a/src/com/massivecraft/factions/integration/worldguard/EngineWorldGuard.java
+++ b/src/com/massivecraft/factions/integration/worldguard/EngineWorldGuard.java
@@ -44,14 +44,7 @@ public class EngineWorldGuard extends Engine
 	@Override
 	public void setActiveInner(boolean active)
 	{
-		if (active)
-		{
-			this.worldGuard = WGBukkit.getPlugin();
-		}
-		else
-		{
 			this.worldGuard = null;
-		}
 	}
 	
 	// -------------------------------------------- //


### PR DESCRIPTION
To provide a fix for the errors in console when using with worldguard in Minecraft 1.13.X